### PR TITLE
fix: Major bugfix in ProtWeaver, Consistency updates to EstimRearrScen

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -28,6 +28,8 @@ export(GetProtWebData)
 S3method(`[`, "LinkedPairs")
 S3method(print, "LinkedPairs")
 
+S3method(print, 'GenRearr')
+
 export(ProtWeaver)
 S3method(show, 'ProtWeaver')
 S3method(print, 'ProtWeaver')

--- a/R/EstimRearrScen.R
+++ b/R/EstimRearrScen.R
@@ -697,9 +697,11 @@ EstimRearrScen <- function(SyntenyObject,
         rearrangements$Scenario <- unlist(chrom_results$scenario)
         rearrangements$Key <- chrom_results$block_key
         
+      }
         # These aren't fully fleshed out and will probably be worse to include at this point
         rearrangements$Gen1Dup <- rearrangements$Gen2Dup <- rearrangements$Translocations <- rearrangements$InsDel <- NULL
-      }
+        if (is.null(rearrangements$Scenario)) rearrangements$Scenario <- 'No events'
+        if (is.null(rearrangements$Key)) rearrangements$Key <- NA
       rearr_mat[[gen1, gen2]] <- rearrangements
       rearrangements <- list("Translocations"=0, "Gen1Dup"=0, "Gen2Dup"=0, "Inversions"=0, "Transpositions"=0, "InsDel"=0)
     }

--- a/R/EstimRearrScen.R
+++ b/R/EstimRearrScen.R
@@ -298,7 +298,7 @@ EstimRearrScen <- function(SyntenyObject,
                 graph <- new_graph
                 #then we just do a DCJ on the left vertex of this block and its connected gray vertex
                 graph <- DCJ(graph, cut_vertex, graph[cut_vertex, 2])
-                rearrangements[[block_count + invert_count +2]] <- paste("block interchange: ", paste(graph_to_genome(graph), collapse=" "), "{", len_block, "}")
+                rearrangements[[block_count + invert_count +2]] <- paste("transposition: ", paste(graph_to_genome(graph), collapse=" "), "{", len_block, "}")
                 block_count <- block_count + 1
                 done <- FALSE
                 break()   
@@ -710,6 +710,31 @@ EstimRearrScen <- function(SyntenyObject,
     cat('\nDone.\n\nTime difference of', 
         round(difftime(Sys.time(), starttime, units = 'secs'), 2),
         'seconds.\n')
+  class(rearr_mat) <- append('GenRearr', class(rearr_mat))
   return(rearr_mat)
 }
 
+print.GenRearr <- function(x, ...){
+  to_print <- matrix(character(), nrow=nrow(x)+1, ncol=ncol(x)+1)
+  to_print[1,] <- c('', colnames(x))
+  nc <- ncol(x)
+  rnames <- rownames(x)
+  for (i in seq_len(nrow(x))){
+    row <- x[i,]
+    outvec <- character(nc)
+    for ( j in seq_along(outvec) ){
+      entry <- row[[j]]
+      if (is(entry, 'character')) outvec[j] <- entry
+      else if (is(entry, 'integer')) outvec[j] <- paste0(length(entry), ' Chromosomes')
+      else {
+        outvec[j] <- paste0(entry$Inversions, 'I,', entry$Transpositions, 'T')
+      }
+    }
+    outvec <- c(rnames[i], outvec)
+    to_print[i+1,] <- outvec
+  }
+  lines <- format(to_print, justify='centre')
+  for (i in seq_len(nrow(lines))) cat(lines[i,], '\n')
+  
+  return(invisible(x))
+}

--- a/R/EstimRearrScen.R
+++ b/R/EstimRearrScen.R
@@ -727,7 +727,7 @@ print.GenRearr <- function(x, ...){
       if (is(entry, 'character')) outvec[j] <- entry
       else if (is(entry, 'integer')) outvec[j] <- paste0(length(entry), ' Chromosomes')
       else {
-        outvec[j] <- paste0(entry$Inversions, 'I,', entry$Transpositions, 'T')
+        outvec[j] <- paste0(round(entry$Inversions, 1), 'I,', round(entry$Transpositions,1), 'T')
       }
     }
     outvec <- c(rnames[i], outvec)

--- a/R/ProtWeaver-class.R
+++ b/R/ProtWeaver-class.R
@@ -226,16 +226,6 @@ PAStats <- function(predDf, paps){
   return(list(avg=av, diff=d))
 }
 
-# RemoveCophParalogs <- function(Coph, useColoc=FALSE){
-#   if (useColoc){
-#     rownamevec <- gsub('(.*)_.*_[0-9]*', '\\1', rownames(Coph))
-#   } else {
-#     rownamevec <- rownames(Coph)
-#   }
-#   
-#   paralogs <- 
-# }
-
 DCA_minimize_fxn <- function(params, R, spins, i){
   sigi <- spins[,i]
   sigj <- spins[,-i]

--- a/man/EstimRearrScen.Rd
+++ b/man/EstimRearrScen.Rd
@@ -12,6 +12,7 @@ Take in a \code{\link[=Synteny-class]{Synteny}} object and return predicted rear
 EstimRearrScen(SyntenyObject, NumRuns = -1,
                 Mean = FALSE, MinBlockLength = -1,
                 Verbose = TRUE)
+                
 }
 
 \arguments{
@@ -78,7 +79,8 @@ try to find the minimum amount of events. Users can choose to receive the best f
 solution or the mean number of events from all solutions.
 }
 \value{
-An \emph{NxN} matrix with the same shape as the input Synteny object. 
+An \emph{NxN} matrix of lists with the same shape as the input Synteny object. This is 
+wrapped into a \code{GenRearr} object for pretty printing.
 
 The diagonal corresponds to total sequence length of the corresponding genome. 
 
@@ -96,6 +98,10 @@ rearrangement scenario found. See below for details.
 See below for details.
 }
 
+The \code{print.GenRearr} method prints this data out as a matrix, with the diagonal
+showing the number of chromosomes and the lower triangle displaying \code{xI,yT}, where
+\code{x,y} the number of inversions and transpositions (resp.) between the
+corresponding entries.
 
 The \code{$Scenario} entry describes a sequences of steps to rearrange one genome 
 into another, as found by this algorithm. The goal of the DCJ model is to rearrange
@@ -116,7 +122,7 @@ entries of genome 2, the entry in \code{$Scenario} would be:
 \code{inversion: 3 1 2 4 \{ 2 \}}
 
 Here we inverted the whole block \code{(-2 -1)} into \code{(1 2)}. We could then 
-finish the rearrangement by performing a block interchange to move block 3 between 
+finish the rearrangement by performing a transposition to move block 3 between 
 2 and 4. The entries of \code{$Scenario} in this case would be the following:
 
 \code{Original: 3 -2 -1 4}

--- a/man/EstimRearrScen.Rd
+++ b/man/EstimRearrScen.Rd
@@ -129,21 +129,20 @@ Step 1 is the original state of genome 2, step 2 inverts 2 elements to arrive at
 \code{(3 1 2 4)}, and then step 3 moves one element to arrive at \code{(1 2 3 4)}. 
 
 It is important to note that the numbered genomic regions in \code{$Scenario} are not genes,
-they are blocks of syntentic regions between the genomes. These blocks may not match
+they are blocks of conserved syntenic regions between the genomes. These blocks may not match
 up with the original blocks from the Synteny object, since some are combined during
 pre-processing to expedite calculations. 
 
-\code{$Key} is a mapping between these numbered regions and the original genetic regions.
+\code{$Key} is a mapping between these numbered regions and the original genomic regions.
 This is a 5 column matrix with the following columns (in order):
 \enumerate{
-  \item \code{start1}: Nucleotide positon for the first nucleotide in of the syntenic region
+  \item \code{start1}: Nucleotide position for the first nucleotide in of the syntenic region
   on genome 1.
   \item \code{start2}: Same as \code{start1}, but for genome 2
   \item \code{length}: Length of block, in nucleotides
   \item \code{rel_direction_on_2}: 1 if the blocks have the same transcriptonal direction on both 
   genomes, and 0 if the direction is reversed in genome 2
   \item \code{index1}: Label of the genetic region used in \code{$Scenario} output
-}
 }
 }
 \references{

--- a/man/predict.ProtWeaver.Rd
+++ b/man/predict.ProtWeaver.Rd
@@ -82,7 +82,7 @@ matrix with some extra S3 methods to make printing cleaner.
     Logical indicating whether to print progress bars and messages. Defaults to \code{TRUE}.
   }
   \item{...}{
-    Additional parameters for consistency with generic.
+    Additional parameters for other predictors and consistency with generic.
   }
 }
 


### PR DESCRIPTION
Fixed a major bug in ProtWeaver and made some general consistency updates

### Major Updates:
- Major bug in ProtWeaver rendered MirrorTree and ContextTree algorithms nonfunctional. This PR resolves these issues.
- New S3 method for pretty printing of `EstimRearrScen` output

### Minor Updates:
- Small documentation updates
- Changes to `EstimRearrScen` to be consistent with word usage

### Build Checks

- [x] Passed `R CMD check`?
- [x] Passed `BiocCheck()`?