### PR TITLE
fix: Handling of dendrograms in ProtWeaver

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# SynExtend 1.7.14
+* Various improvements for `GenRearrScen`, improves consistency and output formatting
+* Major bugfix for `ProtWeaver` methods using dendrogram objects
+* `ProtWeaver` now correctly guards against non-bifurcating dendrograms in methods that expect it
+
 # SynExtend 1.7.13
 * Introduces new `ProtWeaver` class to predict functional association of genes from COGs or gene trees. This implements many algorithms commonly used in the literature, such as MirrorTree and Inverse Potts Models.
 * `predict(ProtWeaverObject)` returns a `ProtWeb` class with information on predicted associations. 

--- a/R/ProtWeaver-class.R
+++ b/R/ProtWeaver-class.R
@@ -226,6 +226,16 @@ PAStats <- function(predDf, paps){
   return(list(avg=av, diff=d))
 }
 
+CheckBifurcating <- function(dend){
+  # Checks if a dendrogram is bifurcating
+  helperfunc <- function(node){
+    if (length(node) == 1) return(TRUE)
+    if (length(node) > 2) return(FALSE)
+    return(helperfunc(node[[1]]) & helperfunc(node[[2]]))
+  }
+  return(helperfunc(dend))
+}
+
 DCA_minimize_fxn <- function(params, R, spins, i){
   sigi <- spins[,i]
   sigj <- spins[,-i]
@@ -970,6 +980,7 @@ Behdenna.ProtWeaver <- function(pw, Subset=NULL, Verbose=TRUE,
                                 useACCTRAN=TRUE, rawZScores=FALSE, 
                                 precalcProfs=NULL, precalcSubset=NULL, ...){
   stopifnot('No species tree provided.'=(!is.null(MySpeciesTree)))
+  stopifnot("Method 'Behdenna' requires a bifurcating tree"=CheckBifurcating(MySpeciesTree))
   if (!is.null(precalcSubset))
     subs <- precalcSubset
   else
@@ -1075,7 +1086,7 @@ Ensemble.ProtWeaver <- function(pw,
     submodels <- c(submodels, takesCP)
   }
   
-  if (!is.null(MySpeciesTree)){
+  if (!is.null(MySpeciesTree) && CheckBifurcating(MySpeciesTree)){
     submodels <- c(submodels, 'Behdenna')
   }
 

--- a/man/predict.ProtWeaver.Rd
+++ b/man/predict.ProtWeaver.Rd
@@ -46,8 +46,9 @@ matrix with some extra S3 methods to make printing cleaner.
     forking via \code{mclapply}.
   }
   \item{MySpeciesTree}{
-    Phylogenetic tree of all genomes in the dataset. Required for method \code{'Behdenna'},
-    and can improve predictions for other methods.
+    Phylogenetic tree of all genomes in the dataset. Required for \code{Method='Behdenna'},
+    and can improve predictions for other methods. \code{'Behdenna'} requires a 
+    rooted, bifurcating tree (other values of \code{Method} can handle arbitrary trees).
   }
   \item{PretrainedModel}{
     A pretrained model for use with ensemble predictions. If unspecified when 
@@ -107,6 +108,13 @@ results slightly nicer. Data can be extracted form the \code{ProtWeb} object wit
 
 \code{GetProtWebData(ProtWebObject, AsDf=c(T,F))}
 
+Different methods require different types of input. The constructor 
+\code{\link{ProtWeaver}} will notify the user which methods are
+runnable with the given data. Note that method \code{Behdenna} requires a species 
+tree, which must be bifurcating. Method \code{Ensemble} automatically selects the 
+methods that can be run with the given input data. 
+
+See \code{\link{ProtWeaver}} for more information on input data types.
 }
 \value{
 Returns a ProtWeb object. See \code{\link[=GetProtWebData.ProtWeb]{GetProtWebData}} for more info.


### PR DESCRIPTION
Fixed handling of dendrograms in protweaver, guards against non-bifurcation when expected.
Updates news

### Build Checks
- [x] Passed `R CMD check`?
- [x] Passed `BiocCheck()`?
