### PR TITLE
fix: bugfixes and features for `ShuffleC`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SynExtend
 Type: Package
 Title: Tools for Working With Synteny Objects
-Version: 1.11.3
+Version: 1.11.4
 Authors@R: c(
 	person("Nicholas", "Cooley", email = "npc19@pitt.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6029-304X")),
 	person("Aidan", "Lakshman", email = "ahl27@pitt.edu", role = c("aut", "ctb"), comment = c(ORCID = "0000-0002-9465-6785")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# SynExtend 1.11.4
+* Internal code refactor
+* `ShuffleC` now supports reproducibility using R's `set.seed`
+* `ShuffleC` now support sampling with replacement, performance is around 2.25x faster than `sample`
+
 # SynExtend 1.11.3
 * Internal bugfixes for JRF Distance--previous commit was incorrectly calculating values
 * Adds new `TreeDistance` predictor for `ProtWeaver`, incorporating all tree distance metrics; these metrics are bundled due to some backend optimizations that improve performance
@@ -6,6 +11,8 @@
 * New internal random number generator using xorshift, significantly faster than `sample()`
 * `HammingGL` changed to `CorrGL`, now uses Pearson's R weighted by p-value
 * Refactors internal predictors to reduce size of codebase and remove redundancies
+* Internal `ShuffleC` function to replicate `sample` functionality with 2-6x speedup
+* Method `GainLoss` now uses bootstrapping to estimate a p-value
 * Updates to documentation files
 
 # SynExtend 1.11.2

--- a/R/ShuffleC.R
+++ b/R/ShuffleC.R
@@ -1,9 +1,19 @@
-ShuffleC <- function(vec, n=length(vec)){
-  stopifnot(n > 0 && n <= length(vec))
+ShuffleC <- function(vec, n=length(vec), replace=FALSE){
+  stopifnot(n > 0 && (replace || n <= length(vec)))
+  if (replace)
+    return(ShuffleWithRecomb(vec, n))
+  
   trimlen <- seq_len(n)
   if(is(vec, 'integer')){
     return(.C("shuffleRInt", vec, n)[[1]][trimlen])
   } else {
     return(vec[.C("shuffleRInt", seq_len(length(vec)), n)[[1]]][trimlen])
   }
+}
+
+ShuffleWithRecomb <- function(vec, n=length(vec)){
+  n <- as.integer(n)
+  l <- length(vec)
+  idxes <- .C("shuffleRRepl", seq_len(n), n)[[1L]] %% l + 1L
+  return(vec[idxes])
 }

--- a/src/CShuffle.c
+++ b/src/CShuffle.c
@@ -1,0 +1,33 @@
+#include <R.h>
+#include <Rdefines.h>
+#include <R_ext/Rdynload.h>
+#include <R_ext/Utils.h>
+#include <R_ext/Random.h>
+#include <Rinternals.h>
+#include <math.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "SynExtend.h"
+#include "SEutils.h"
+
+/*** R .C Functions ***/
+void shuffleRInt(int *v, int *l){ 
+  GetRNGstate();
+  shuffle(int, v, *l); 
+  PutRNGstate();
+}
+
+void shuffleRRepl(int *v, int *l){ 
+  GetRNGstate();
+  struct RNGstate32 *r = malloc(sizeof(struct RNGstate32));
+  uint64_t seed = (((uint64_t)irand()) << 32) | ((uint64_t)irand());
+  seedRNGState32(r, seed);
+  for (int i=0; i<*l; i++)
+    v[i] = (xorshift32b(r) >> 1);
+
+  PutRNGstate();
+  return;
+}
+
+

--- a/src/CShuffle.h
+++ b/src/CShuffle.h
@@ -1,4 +1,0 @@
-#include "SEutils.h"
-
-/*** R .Call Functions ***/
-void shuffleRInt(int *v, int *l){ shuffle(int, v, *l); }

--- a/src/R_init_synextend.c
+++ b/src/R_init_synextend.c
@@ -25,7 +25,7 @@
 #include "SynExtend.h"
 
 // Other header files for .C Routines
-#include "CShuffle.h"
+#include "SEutils.h"
 
 /*
  * -- REGISTRATION OF THE .Call ENTRY POINTS ---
@@ -58,7 +58,7 @@ static const R_CallMethodDef callMethods[] = { // method call, pointer, num args
 static const R_CMethodDef cMethods[] = {
   {"cleanupFxn", (DL_FUNC) &cleanupFxn, 0},
   {"shuffleRInt", (DL_FUNC) &shuffleRInt, 2},
-  {"shuffleRDouble", (DL_FUNC) &shuffleRInt, 2},
+  {"shuffleRRepl", (DL_FUNC) &shuffleRRepl, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/SEutils.h
+++ b/src/SEutils.h
@@ -1,3 +1,6 @@
+#ifndef UTIL_FILE
+#define UTIL_FILE
+
 // Various utility functions
 #include <stdlib.h>
 #include <math.h>
@@ -65,10 +68,11 @@ void seedRNGState32(struct RNGstate32 *r, uint64_t seed);
 
 uint32_t xorshift32b(struct RNGstate32 *r);
 
-
 /*** Random math functions ***/
 long inline doubleFactorial(int n){
   long retval = 1;
   while (n > 0) retval *= n--;
   return retval;
 }
+
+#endif

--- a/src/SynExtend.h
+++ b/src/SynExtend.h
@@ -32,3 +32,9 @@ SEXP calcDBrownValue(SEXP tnPtr, SEXP allLabels, SEXP iterNum, SEXP SD, SEXP STA
 SEXP pseudoRandomSample(SEXP N);
 SEXP randomProjection(SEXP VEC, SEXP NONZERO, SEXP N, SEXP OUTDIM);
 SEXP seededPseudoRandomSample(SEXP N, SEXP SEED);
+
+
+/**** CShuffle.c ****/
+void shuffleRInt(int *v, int *l);
+
+void shuffleRRepl(int *v, int *l);


### PR DESCRIPTION
* `ShuffleC` now supports sampling with replacement (2.2x speedup over base `sample`) 
* `ShuffleC` now correctly interacts with `set.seed()`
* Refactored some C code internally