### PR TITLE
feat: PAPV method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SynExtend
 Type: Package
 Title: Tools for Working With Synteny Objects
-Version: 1.13.3
+Version: 1.13.4
 Authors@R: c(
 	person("Nicholas", "Cooley", email = "npc19@pitt.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6029-304X")),
 	person("Aidan", "Lakshman", email = "ahl27@pitt.edu", role = c("aut", "ctb"), comment = c(ORCID = "0000-0002-9465-6785")),

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -48,20 +48,25 @@ S3method(predict, 'ProtWeaver')
 S3method(PAProfiles, 'ProtWeaver')
 S3method(CophProfiles, 'ProtWeaver')
 S3method(RandCophProfiles, 'ProtWeaver')
+S3method(Ensemble, 'ProtWeaver')
+
 S3method(Jaccard, 'ProtWeaver')
 S3method(Hamming, 'ProtWeaver')
 S3method(MutualInformation, 'ProtWeaver')
 S3method(GainLoss, 'ProtWeaver')
 S3method(CorrGL, 'ProtWeaver')
+S3method(ProfileDCA, 'ProtWeaver')
+S3method(Behdenna, 'ProtWeaver')
+S3method(PAPV, 'ProtWeaver')
+
 S3method(MirrorTree, 'ProtWeaver')
 S3method(ContextTree, 'ProtWeaver')
 S3method(TreeDistance, 'ProtWeaver')
-S3method(ProfileDCA, 'ProtWeaver')
+
 S3method(Coloc, 'ProtWeaver')
 S3method(ColocMoran, 'ProtWeaver')
 S3method(TranscripMI, 'ProtWeaver')
-S3method(Behdenna, 'ProtWeaver')
-S3method(Ensemble, 'ProtWeaver')
+
 S3method(NVDT, 'ProtWeaver')
 S3method(Ancestral, 'ProtWeaver')
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# SynExtend 1.13.4
+* New predictor `PAPV.ProtWeaver` to calculate p-values for presence/absence profiles. 
+* `ContextTree` now uses `MirrorTree` with species tree correction and p/a overlap correction
+* Updates to documentation
+
 # SynExtend 1.13.3
 * `predict.ProtWeaver` now supports multiple algorithms at once (ex. `predict(pw, Method=c("Jaccard", "Hamming"))`)
 * Documentation for `ProtWeaver` and associated methods has been updated to match recent updates.

--- a/R/ProtWeaver-DMPreds.R
+++ b/R/ProtWeaver-DMPreds.R
@@ -90,6 +90,7 @@ MirrorTree.ProtWeaver <- function(pw, MTCorrection=c(),
     if (Verbose) cat('\n')
   }
   
+  useOverlap <- ('paoverlap' %in% MTCorrection)
   pairscores <- rep(NA_real_, pl*(pl-1) / 2)
   ctr <- 0
   endOfRow <- 0
@@ -122,7 +123,9 @@ MirrorTree.ProtWeaver <- function(pw, MTCorrection=c(),
                                         method='spearman'))
             num_branch <- length(v1)
             pval <- 1 - exp(pt(val, num_branch-2, lower.tail=FALSE, log.p=TRUE))
-            overlap <- length(intersect(l1,l2)) / length(unique(c(l1,l2)))
+            overlap <- 1L
+            if(useOverlap)
+              overlap <- length(intersect(l1,l2)) / length(unique(c(l1,l2)))
             val <- val*pval*overlap
           }
           pairscores[ctr+1] <- ifelse(is.na(val), 0, val)
@@ -147,7 +150,7 @@ ContextTree.ProtWeaver <- function(pw, Subset=NULL, Verbose=TRUE, precalcProfs=N
   }
   
   #MTCorrection <- c('speciestree', 'normalize', 'partialcorrelation')
-  MTCorrection <- c('speciestree', 'satoaverage')
+  MTCorrection <- c('speciestree', 'paoverlap')
   
   return(MirrorTree(pw, MTCorrection=MTCorrection,
                     Verbose=Verbose, 

--- a/R/ProtWeaver-PAPreds.R
+++ b/R/ProtWeaver-PAPreds.R
@@ -49,7 +49,9 @@ Jaccard.ProtWeaver <- function(pw, Subset=NULL, Verbose=TRUE,
   pap[] <- as.integer(pap) 
   ARGS <- list(nr=nr)
   FXN <- function(v1, v2, ARGS, ii, jj) {
-    return(.Call("calcScoreJaccard", v1, v2, ARGS$nr, PACKAGE="SynExtend"))
+    score <- .Call("calcScoreJaccard", v1, v2, ARGS$nr, PACKAGE="SynExtend")
+    pval <- fisher.test(v1, v2, simulate.p.value=TRUE)
+    return(score * (1-pval))
   }
   pairscores <- BuildSimMatInternal(pap, uvals, evalmap, l, n, FXN, ARGS, Verbose)
 

--- a/R/ProtWeaver-PAPreds.R
+++ b/R/ProtWeaver-PAPreds.R
@@ -20,6 +20,7 @@ MutualInformation <- function(pw, ...) UseMethod('MutualInformation')
 ProfileDCA <- function(pw, ...) UseMethod('ProfileDCA')
 Behdenna <- function(pw, ...) UseMethod('Behdenna')
 GainLoss <- function(pw, ...) UseMethod('GainLoss')
+PAPV <- function(pw, ...) UseMethod('PAPV')
 ################################
 
 Jaccard.ProtWeaver <- function(pw, Subset=NULL, Verbose=TRUE,
@@ -49,9 +50,7 @@ Jaccard.ProtWeaver <- function(pw, Subset=NULL, Verbose=TRUE,
   pap[] <- as.integer(pap) 
   ARGS <- list(nr=nr)
   FXN <- function(v1, v2, ARGS, ii, jj) {
-    score <- .Call("calcScoreJaccard", v1, v2, ARGS$nr, PACKAGE="SynExtend")
-    pval <- fisher.test(v1, v2, simulate.p.value=TRUE)
-    return(score * (1-pval))
+    return(.Call("calcScoreJaccard", v1, v2, ARGS$nr, PACKAGE="SynExtend"))
   }
   pairscores <- BuildSimMatInternal(pap, uvals, evalmap, l, n, FXN, ARGS, Verbose)
 
@@ -425,5 +424,39 @@ GainLoss.ProtWeaver <- function(pw, Subset=NULL,
   pairscores <- BuildSimMatInternal(glvs, uvals, evalmap, l, names(pw), 
                                     FXN, ARGS, Verbose)
 
+  return(pairscores)
+}
+
+PAPV.ProtWeaver <- function(pw, Subset=NULL, Verbose=TRUE,
+                               precalcProfs=NULL, precalcSubset=NULL, ...){
+  
+  if (!is.null(precalcSubset))
+    subs <- precalcSubset
+  else
+    subs <- ProcessSubset(pw, Subset)
+  uvals <- subs$uvals
+  evalmap <- subs$evalmap
+  
+  if ( is.null(precalcProfs) ){
+    if (Verbose) cat('Calculating PA Profiles...\n')
+    pap <- PAProfiles(pw, uvals, Verbose=Verbose)
+  } else {
+    pap <- precalcProfs
+  }
+  l <- length(uvals)
+  n <- names(pw)
+  if ( l == 1 ){
+    mat <- matrix(1, nrow=1, ncol=1)
+    rownames(mat) <- colnames(mat) <- n
+    return(mat)
+  }
+  nr <- nrow(pap)
+  pap[] <- as.integer(pap) 
+  ARGS <- list(nr=nr)
+  FXN <- function(v1, v2, ARGS, ii, jj) {
+    return(1-fisher.test(v1, v2, simulate.p.value=TRUE)$p.value)
+  }
+  pairscores <- BuildSimMatInternal(pap, uvals, evalmap, l, n, FXN, ARGS, Verbose)
+  
   return(pairscores)
 }

--- a/man/ProtWeaver-DMPreds.Rd
+++ b/man/ProtWeaver-DMPreds.Rd
@@ -43,9 +43,7 @@ multiple ways to improve predictions from the initial \code{MirrorTree} method.
 These methods incorporate additional phylogenetic context, and are thus
 called \code{ContextTree} methods. These improvements include correcting
 for overall evolutionary rate using a species tree and/or using projection vectors.
-The built-in \code{ContextTree} method implements these corrections, which can perform
-better on sets of genomes with high similarity (low evolutionary divergence). 
-Note that the projection vector correction is not compatible with parallel implementation.
+The built-in \code{ContextTree} method implements a species tree correction, and weights the resulting score by the normalized Hamming distance of the presence/absence profiles. This can correct for gene trees with low overlap that achieve spuriously high scores via random projection. Additional correction measures are implemented in the \code{MTCorrection} argument.
 
 The \code{TreeDistance} method uses phylogenetic tree distance to quantify differences between gene trees. This method implements a number of metrics and groups them together to improve overall runtime. Individual methods can be specified using the \code{TreeMethods} argument, which expects a character vector containing one or more of the following:
 \itemize{

--- a/man/ProtWeaver-PAPreds.Rd
+++ b/man/ProtWeaver-PAPreds.Rd
@@ -17,12 +17,13 @@ methods and algorithms. Presence/Absence (PA) methods examine conservation
 of gain/loss events within orthology groups using phylogenetic profiles
 constructed from presence/absence patterns.
 
-\code{predict.ProtWeaver} currently supports six PA methods:
+\code{predict.ProtWeaver} currently supports seven PA methods:
 \itemize{
   \item \code{'Jaccard'}
   \item \code{'Hamming'}
-  \item \code{'CorrGL'}
   \item \code{'MutualInformation'}
+  \item \code{'PAPV'}
+  \item \code{'CorrGL'}
   \item \code{'ProfDCA'}
   \item \code{'Behdenna'}
   \item \code{'GainLoss'}
@@ -43,6 +44,8 @@ Methods \code{Hamming} and \code{Jaccard} use Hamming and Jaccard distance
 \code{MutualInformation} uses mutual information of PA profiels to determine
 score, employing a weighting scheme such that \eqn{11} and \eqn{00} give
 positive information, and \eqn{10} and \eqn{01} give negative information. 
+
+\code{PAPV} calculates a p-value for PA profiles using Fisher's Exact Test. The returned score is provided as \code{1-p_value} so that larger scores indicate more significance, and smaller scores indicate less significance. This rescaling is consistent with the other similarity metrics in \code{ProtWeaver}. This can be used with \code{Jaccard}, \code{Hamming}, or \code{MutualInformation} to weight raw scores by statistical significance.
 
 \code{ProfDCA} uses the direct coupling analysis algorithm introduced by
 Weigt et al. (2005) to determine direct information between PA profiles.

--- a/man/predict.ProtWeaver.Rd
+++ b/man/predict.ProtWeaver.Rd
@@ -88,6 +88,7 @@ matrix with some extra S3 methods to make printing cleaner.
   \item \code{'Jaccard'}: Jaccard distance of Presence/Absence (P/A) profiles
   \item \code{'Hamming'}: Hamming distance of P/A profiles
   \item \code{'MutualInformation'}: MI of P/A profiles
+  \item \code{'PAPV'}: \code{1-p_value} of P/A profiles
   \item \code{'ProfDCA'}: Direct Coupling Analysis of P/A profiles
   \item \code{'Behdenna'}: Analysis of Gain/Loss events following Behdenna et al. (2016) 
   \item \code{'CorrGL'}: Correlation of ancestral Gain/Loss events


### PR DESCRIPTION
Adds method to calculate p-value for presence/absence profiles--this is bundled into a single method because the calculation is the exact same for Jaccard, Hamming, and MutualInformation methods. Will make things easier down the line when p-values are split out from final scores.