### PR TITLE
fix: bug in `PhyloDistance`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SynExtend
 Type: Package
 Title: Tools for Working With Synteny Objects
-Version: 1.15.0
+Version: 1.15.1
 Authors@R: c(
 	person("Nicholas", "Cooley", email = "npc19@pitt.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6029-304X")),
 	person("Aidan", "Lakshman", email = "ahl27@pitt.edu", role = c("aut", "ctb"), comment = c(ORCID = "0000-0002-9465-6785")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# SynExtend 1.15.1
+* Fixes bug in JRF distance causing scores to be higher than expected.
+
 # SynExtend 1.13.8
 * Updates to all EvoWeaver documentation files
 * Fixed small bug in `PhyloDistance` causing `Method='JRF'` to return similarity rather than the distance

--- a/R/EvoWeaver-PSPreds.R
+++ b/R/EvoWeaver-PSPreds.R
@@ -167,6 +167,8 @@ TreeDistance.EvoWeaver <- function(ew, Subset=NULL, Verbose=TRUE,
     subs <- ProcessSubset(ew, Subset)
   uvals <- subs$uvals
   evalmap <- subs$evalmap
+  if(!is.numeric(JRFk)) stop("JRFk value must be numeric")
+  if(is.integer(JRFk)) JRFk <- as.numeric(JRFk)
   
   useColoc <- attr(ew, "useColoc")
   l <- length(uvals)

--- a/R/EvoWeaver-class.R
+++ b/R/EvoWeaver-class.R
@@ -215,7 +215,7 @@ predict.EvoWeaver <- function(object, Method='Ensemble', Subset=NULL, Processors
       if (length(rs) == 1) rs <- rs[[1]]
       methodnames <- c(methodnames, pnames)
     } else {
-      names(preds) <- n
+      #names(preds) <- n
       rs <- structure(preds,
                       method=methodtype,
                       class=c('EvoWeb', 'simMat'))

--- a/R/PhyloDistance.R
+++ b/R/PhyloDistance.R
@@ -68,14 +68,12 @@ JRFDist <- function(val, RawScore=FALSE){
   if (RawScore){
     retval <- val
     names(retval) <- c("Distance", "dend1.NumSplits", "dend2.NumSplits")
-    if (val[1] == 0) retval[c(1,2)] <- c(NA, NA)
     return(retval)
   }
-  if (val[1] == 0) return(1)
   maxval <- (val[2] + val[3])
   retval <- val[1] / maxval
   if (maxval == 0)
-    retval <- as.integer(val[1] != 0)
+    retval <- as.integer(val[1] == 0)
   return(retval)
 }
 

--- a/src/CDend.c
+++ b/src/CDend.c
@@ -873,17 +873,16 @@ double scoreJaccardRFDist(bool **pm1, bool **pm2, int pm1l, int pm2l, int lh, do
   int numFound = 0;
   bool found;
 
-  // counts stores all the pairwise counts, as follows:
-  // [A1, A2, B1, B2, A1A2, A1B2, B1A2, B1B2]
-  // note that B1 = !A1, B2 = !A2
-  int counts[8];
   for (int i=0; i<shortl; i++){
     R_CheckUserInterrupt();
-    minval = 1;
+    // Mistake in the original paper for this
+    // they say that the value 2-2(JRFScore) approaches 1 for k->infty, but this is wrong
+    // it's actually 2, which corresponds to 1 *per partition*
+    // The worst score should be 2 (leaving unpaired), and the best should be zero
+    minval = 2;
     curS = shortPm[i];
     found = false;
      for (int j=0; j<(longl-numFound); j++){
-      memset(counts, 0, sizeof(counts));
       curL = longPm[j];
       cursum = 2 - 2*calcJaccardPairingScore(curS, curL, lh, expv);
       if (cursum < minval){
@@ -893,15 +892,16 @@ double scoreJaccardRFDist(bool **pm1, bool **pm2, int pm1l, int pm2l, int lh, do
       }
     }
 
-    retval += minval;
     // swap in the last column so we don't search it again
     if (found){
+      retval += minval;
       memcpy(longPm[idxchange], longPm[longl-numFound-1], lh);
       numFound++;
     }
   }
   // numFound is the number of pairs
   // Thus we have (shortl-numFound) + (longl-numFound) unpaired entries
+  // note that shortl and longl are 0-indexed, so we need to add one to each
   retval += (shortl + longl - 2*numFound);
 
   return retval;
@@ -909,7 +909,7 @@ double scoreJaccardRFDist(bool **pm1, bool **pm2, int pm1l, int pm2l, int lh, do
 
 double calcJaccardPairingScore(bool *v1, bool *v2, int lh, double expv){
   double vals[8];
-  memset(vals, 0, sizeof(int) * 8);
+  memset(vals, 0, sizeof(double) * 8);
 
   /****
    * We have two sets, A and B.
@@ -938,7 +938,6 @@ double calcJaccardPairingScore(bool *v1, bool *v2, int lh, double expv){
 
   for (int i=0; i<4; i++)
     vals[i] = vals[i+4] == 0 ? 0 : pow(vals[i] / vals[i+4], expv);
-
 
   vals[0] = vals[0] < vals[3] ? vals[0] : vals[3];
   vals[1] = vals[1] < vals[2] ? vals[1] : vals[2];

--- a/src/CDend.c
+++ b/src/CDend.c
@@ -188,8 +188,8 @@ SEXP GRFInfo(SEXP tnPtr1, SEXP tnPtr2, SEXP allLabels, SEXP shouldUseJRF, SEXP J
   double RFscore, entropy1, entropy2;
   if (useJRF){
     RFscore = scoreJaccardRFDist(part1, part2, t1pln, t2pln, numLabels, jaccardExp);
-    entropy1 = t1pln;
-    entropy2 = t2pln;
+    entropy1 = (double) t1pln;
+    entropy2 = (double) t2pln;
   } else {
     RFscore = scorePMs(part1, part2, t1pln, t2pln, numLabels);
     entropy1 = calcEntropy(part1, numLabels, t1pln);


### PR DESCRIPTION
`PhyloDistance` was miscalculating distance when `Method="JRF"`. This was caused by me misinterpreting the original publication; their text has a mistake in how they define JRF distance. This fixes that issue.