### PR TITLE
fix: small bug in EvoWeaver's TreeDistance predictor

### DIFF
--- a/R/EvoWeaver-PSPreds.R
+++ b/R/EvoWeaver-PSPreds.R
@@ -159,7 +159,8 @@ RPContextTree.EvoWeaver <- function(ew, Subset=NULL, Verbose=TRUE, precalcProfs=
                     Verbose=Verbose,
                     precalcCProfs=precalcProfs,
                     MySpeciesTree=MySpeciesTree,
-                    CombinePVal=CombinePVal))
+                    CombinePVal=CombinePVal,
+                    Subset=Subset))
 }
 
 TreeDistance.EvoWeaver <- function(ew, Subset=NULL, Verbose=TRUE,

--- a/R/EvoWeaver-class.R
+++ b/R/EvoWeaver-class.R
@@ -388,7 +388,7 @@ predict.EvoWeaver <- function(object, Method='Ensemble', Subset=NULL, Processors
     if (methodtype=='TreeDistance'){
       pnames <- names(preds)
       for (i in seq_along(pnames)){
-        names(preds[[i]]) <- n
+        #names(preds[[i]]) <- n
         preds[[i]] <- structure(preds[[i]],
                                 method=pnames[i],
                                 class=c('EvoWeb', 'simMat'))


### PR DESCRIPTION
Fixes a bug in `TreeDistance` predictor for EvoWeaver that would occasionally crash predictions when the `Subset` value was set.