### PR TITLE
fix: small documentation and minor bugfix

### DIFF
--- a/R/ExoLabel.R
+++ b/R/ExoLabel.R
@@ -103,10 +103,9 @@ ExoLabel <- function(edgelistfiles, outfile=tempfile(),
   if(verbose) cat("Temporary files stored at ", tempfiledir, "\n")
 
   seps <- paste(sep, "\n", sep='')
-  ctr <- 0
 
   .Call("R_LPOOM_cluster", edgelistfiles, length(edgelistfiles),
-        tempfiledir, outfile, seps, ctr, iterations,
+        tempfiledir, outfile, seps, iterations,
         verbose, is_undirected, add_self_loops, ignore_weights, normalize_weights,
         consensus_cluster, inflation, !use_fast_sort)
 

--- a/man/ExoLabel.Rd
+++ b/man/ExoLabel.Rd
@@ -18,7 +18,7 @@ ExoLabel(edgelistfiles,
               inflation=1.05,
               return_table=FALSE,
               consensus_cluster=FALSE,
-              use_fast_sort=TRUE,
+              use_fast_sort=FALSE,
               verbose=interactive(),
               sep='\t',
               tempfiledir=tempdir())

--- a/man/ExoLabel.Rd
+++ b/man/ExoLabel.Rd
@@ -18,6 +18,7 @@ ExoLabel(edgelistfiles,
               inflation=1.05,
               return_table=FALSE,
               consensus_cluster=FALSE,
+              use_fast_sort=TRUE,
               verbose=interactive(),
               sep='\t',
               tempfiledir=tempdir())

--- a/src/OnDiskLP.c
+++ b/src/OnDiskLP.c
@@ -655,6 +655,8 @@ void kway_mergesort_file_inplace(const char* f1, l_uint nlines,
 
     cur_start = 0;
     for(l_uint iter=0; iter<num_iter; iter++){
+      // DEBUG
+      Rprintf("\n\t%llu/%llu\n", iter, num_iter);
       // run one k-way merge operation
 
       // first initialize offsets and number of remaining values
@@ -665,6 +667,8 @@ void kway_mergesort_file_inplace(const char* f1, l_uint nlines,
         cur_start = cur_start > (nlines) ? nlines : cur_start;
         remaining[i] = cur_start - offsets[i];
       }
+      // DEBUG
+      Rprintf("\tInitialized\n");
 
       // load data into the buffers and assign into tree
       for(int i=0; i<num_bins; i++){
@@ -677,9 +681,13 @@ void kway_mergesort_file_inplace(const char* f1, l_uint nlines,
           offsets[i] += to_read;
         }
       }
+      // DEBUG
+      Rprintf("\tLoaded data\n");
 
       // merge all the data
       LT_initGame(mergetree);
+      // DEBUG
+      Rprintf("\tInit Game\n");
       while(mergetree->full_bins){
         // note cur_start is the first line of the *next* block
         empty_bin = LT_runInplaceFileGame(mergetree, cur_start, fileptr, remaining, &offsets);
@@ -707,6 +715,8 @@ void kway_mergesort_file_inplace(const char* f1, l_uint nlines,
         // so the tree moves on to the next step prior to next pop
         LT_refillBin(mergetree, empty_bin, to_read, buffers[empty_bin]);
       }
+      // DEBUG
+      Rprintf("\tGame Done\n");
 
       // finally, call fdumpOutput to dump any remaining values
       // this doesn't need to call fdumpOutputInplace because there are no
@@ -724,6 +734,9 @@ void kway_mergesort_file_inplace(const char* f1, l_uint nlines,
           }
         R_CheckUserInterrupt();
       }
+
+      // DEBUG
+      Rprintf("\tDumped Output\n");
     }
 
     mergetree->nwritten = 0;
@@ -2084,7 +2097,7 @@ SEXP R_LPOOM_cluster(SEXP FILENAME, SEXP NUM_EFILES, // files
   if(verbose) report_time(time1, time2, "\t");
 
   // allocate space for leaf counters
-  GLOBAL_all_leaves = malloc(sizeof(leaf *) * (num_v));
+  GLOBAL_all_leaves = malloc(sizeof(leaf *) * (num_v+1));
 
   // next, reformat the file to get final counts for each node
   if(verbose) Rprintf("Tidying up internal tables...\n");

--- a/src/R_init_synextend.c
+++ b/src/R_init_synextend.c
@@ -56,7 +56,7 @@ static const R_CallMethodDef callMethods[] = { // method call, pointer, num args
   CALLDEF(do_dendrapply, 4),
   CALLDEF(se_cophenetic, 5),
   CALLDEF(MIForSequenceSets, 7),
-  CALLDEF(R_LPOOM_cluster, 15),
+  CALLDEF(R_LPOOM_cluster, 14),
   CALLDEF(R_learn_tree, 9),
   CALLDEF(R_get_treeptr, 4),
   CALLDEF(R_rfpredict, 4),

--- a/src/SynExtend.h
+++ b/src/SynExtend.h
@@ -65,7 +65,7 @@ SEXP do_dendrapply(SEXP tree, SEXP fn, SEXP env, SEXP order);
 void cleanup_ondisklp_global_values(void);
 SEXP R_LPOOM_cluster(SEXP FILENAME, SEXP NUM_EFILES,
                     SEXP OUTDIR, SEXP OUTFILE,
-                    SEXP SEPS, SEXP CTR, SEXP ITER, SEXP VERBOSE,
+                    SEXP SEPS, SEXP ITER, SEXP VERBOSE,
                     SEXP IS_UNDIRECTED, SEXP ADD_SELF_LOOPS, SEXP IGNORE_WEIGHTS, SEXP NORMALIZE_WEIGHTS,
                     SEXP CONSENSUS_WEIGHTS, SEXP INFLATION_POW, SEXP SORT_INPLACE);
 //SEXP R_TestRW(SEXP FILES, SEXP DIR);


### PR DESCRIPTION
- Documentation update to add previously missing argument
- minor fix to resolve a small bug where nodes with no edges post-inflation would be assigned to cluster 0, which is invalid in the 1-indexed clustering used.
- fixes bug that would sometimes crash R when calling `ExoLabel(..., use_fast_sort=FALSE)`