### PR TITLE
fix: Bugfix for certain input types to ExoLabel, formatting improvements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SynExtend
 Type: Package
 Title: Tools for Working With Synteny Objects
-Version: 1.19.2
+Version: 1.19.3
 Authors@R: c(
 	person("Nicholas", "Cooley", email = "npc19@pitt.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6029-304X")),
 	person("Aidan", "Lakshman", email = "ahl27@pitt.edu", role = c("aut", "ctb"), comment = c(ORCID = "0000-0002-9465-6785")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# SynExtend 1.19.3
+* `ExoLabel` will no longer crash when given a network lacking a trailing newline
+* Various internal improvements and code refinements
+
 # SynExtend 1.19.2
 * Lots of bug fixes for `ExoLabel`
 * `ExoLabel` now reports disk consumption during execution


### PR DESCRIPTION
- removes a lot of old code
- adds more informative error message to tell the user where malformatted lines may be in `ExoLabel`
- adds an additional check so things don't crash if a network missing a trailing newline is given to `ExoLabel`