### PR TITLE
fix: QoL changes to ExoLabel, bugfixes, documentation updates

### DIFF
--- a/R/ExoLabel.R
+++ b/R/ExoLabel.R
@@ -39,7 +39,7 @@ ExoLabel <- function(edgelistfiles, outfile=tempfile(),
   } else if(is.na(ignore_weights) || is.null(ignore_weights)){
     stop("invalid value for 'ignore_weights' (should be TRUE or FALSE)")
   }
-  if(ignore_weights && any(add_self_loops != 0 && add_self_loops != 1)){
+  if(ignore_weights && any(add_self_loops != 0 & add_self_loops != 1)){
     warning("Weight specified for 'add_self_loops' will be ignored")
     add_self_loops <- as.numeric(as.logical(add_self_loops))
   }
@@ -54,7 +54,7 @@ ExoLabel <- function(edgelistfiles, outfile=tempfile(),
   } else if (is.integer(attenuation)){
     attenuation <- as.numeric(attenuation)
   }
-  if(is.na(attenuation) || is.null(attenuation) || is.infinite(attenuation)){
+  if(any(is.na(attenuation) | is.null(attenuation) | is.infinite(attenuation))){
     stop("'attenuation' must be a valid numeric value")
   }
   if(length(add_self_loops) == 1){

--- a/R/ExoLabel.R
+++ b/R/ExoLabel.R
@@ -1,7 +1,7 @@
 ExoLabel <- function(edgelistfiles, outfile=tempfile(),
                           mode=c("undirected", "directed"),
                           add_self_loops=FALSE,
-                          attenuation_power=1,
+                          attenuation=TRUE,
                           ignore_weights=FALSE,
                           iterations=0L,
                           return_table=FALSE,
@@ -25,6 +25,8 @@ ExoLabel <- function(edgelistfiles, outfile=tempfile(),
   }
   if(!is.numeric(add_self_loops) && !is.logical(add_self_loops)){
     stop("value of 'add_self_loops' should be numeric or logical")
+  } else if (is.logical(add_self_loops)){
+    add_self_loops <- as.numeric(add_self_loops)
   }
   if(any(add_self_loops < 0)){
     warning("self loops weight supplied is negative, setting to zero.")
@@ -37,31 +39,34 @@ ExoLabel <- function(edgelistfiles, outfile=tempfile(),
   } else if(is.na(ignore_weights) || is.null(ignore_weights)){
     stop("invalid value for 'ignore_weights' (should be TRUE or FALSE)")
   }
-  if(ignore_weights && (add_self_loops != 0 || add_self_loops != 1)){
+  if(ignore_weights && any(add_self_loops != 0 && add_self_loops != 1)){
     warning("Weight specified for 'add_self_loops' will be ignored")
-    add_self_loops <- 1
+    add_self_loops <- as.numeric(as.logical(add_self_loops))
   }
   if(!is.logical(use_fast_sort)){
     stop("invalid value for 'use_fast_sort' (should be TRUE or FALSE)")
   }
-  if(!is.numeric(attenuation_power)){
-    stop("'attenuation_power' must be a valid numeric value")
-  } else if (is.integer(attenuation_power)){
-    attenuation_power <- as.numeric(attenuation_power)
+  if(is.logical(attenuation)){
+    attenuation <- as.numeric(attenuation)
   }
-  if(is.na(attenuation_power) || is.null(attenuation_power) || is.infinite(attenuation_power)){
-    stop("'attenuation_power' must be a valid numeric value")
+  if(!is.numeric(attenuation)){
+    stop("'attenuation' must be a valid numeric value")
+  } else if (is.integer(attenuation)){
+    attenuation <- as.numeric(attenuation)
+  }
+  if(is.na(attenuation) || is.null(attenuation) || is.infinite(attenuation)){
+    stop("'attenuation' must be a valid numeric value")
   }
   if(length(add_self_loops) == 1){
     add_self_loops <- rep(add_self_loops, length(outfile))
   }
-  if(length(attenuation_power) == 1){
-    attenuation_power <- rep(attenuation_power, length(outfile))
+  if(length(attenuation) == 1){
+    attenuation <- rep(attenuation, length(outfile))
   }
   if(length(outfile) != length(add_self_loops) ||
-     length(attenuation_power) != length(add_self_loops)){
+     length(attenuation) != length(add_self_loops)){
       stop("If more than one outfile is provided, 'add_self_loops' and ",
-          "'attenuation_power' must be either the same length as 'outfile' ",
+          "'attenuation' must be either the same length as 'outfile' ",
           "or length 1.")
   }
   if(!is.logical(verbose) || !is.numeric(verbose)){
@@ -142,7 +147,7 @@ ExoLabel <- function(edgelistfiles, outfile=tempfile(),
                        verbose_int, is_undirected,
                        add_self_loops, ignore_weights,
                        consensus_cluster, !use_fast_sort,
-                       attenuation_power)
+                       attenuation)
   names(graph_stats) <- c("num_vertices", "num_edges")
   for(f in list.files(tempfiledir, full.names=TRUE))
     if(file.exists(f)) file.remove(f)
@@ -150,7 +155,7 @@ ExoLabel <- function(edgelistfiles, outfile=tempfile(),
   retval <- list()
   for(i in seq_along(outfile)){
     param_vec <- c(add_self_loops=add_self_loops[i],
-                   attenuation_power=attenuation_power[i])
+                   attenuation=attenuation[i])
     if(return_table){
       tab <- read.table(outfile[i], sep=sep)
       colnames(tab) <- c("Vertex", "Cluster")

--- a/R/FitchParsimony.R
+++ b/R/FitchParsimony.R
@@ -1,5 +1,10 @@
+### -----
+### This function is named FitchParsimony because it's entirely in R
+### Function fitch_parsimony is internal with a faster C-based implementation
+### The latter is not user-exposed and is used in EvoWeaver
+### -----
 FitchParsimony <- function(dend, num_traits, traits_list,
-                           initial_state=rep(0L,num_traits), 
+                           initial_state=rep(0L,num_traits),
                            fill_ambiguous=TRUE){
   if(is.numeric(num_traits))
     num_traits <- as.integer(num_traits)
@@ -21,8 +26,8 @@ FitchParsimony <- function(dend, num_traits, traits_list,
     s <- rep(0L, num_traits)
     if(is.leaf(x)){
       a <- attr(x, 'label')
-      s <- vapply(seq_len(num_traits), 
-                  \(i) as.integer(a %in% traits_list[[i]]), 
+      s <- vapply(seq_len(num_traits),
+                  \(i) as.integer(a %in% traits_list[[i]]),
                   integer(1L))
     } else {
       s1 <- attr(x[[1]], 'FitchState')
@@ -35,11 +40,11 @@ FitchParsimony <- function(dend, num_traits, traits_list,
     attr(x, 'FitchState') <- s
     x
   }, how='post.order')
-  
+
   # set root to 0,0
   if(!is.null(initial_state))
     attr(dend, 'FitchState') <- initial_state
-  
+
   # downward fitch
   dend <- dendrapply(dend, \(x){
     if(!is.leaf(x)){
@@ -52,8 +57,8 @@ FitchParsimony <- function(dend, num_traits, traits_list,
       }
     }
     x
-  }, how='post.order') 
-  
+  }, how='post.order')
+
   if(fill_ambiguous){
     dend <- dendrapply(dend, \(x){
       s <- attr(x, 'FitchState')
@@ -65,6 +70,6 @@ FitchParsimony <- function(dend, num_traits, traits_list,
       x
     }, how='post.order')
   }
-  
+
   dend
 }

--- a/R/MoranI.R
+++ b/R/MoranI.R
@@ -18,12 +18,8 @@
 # Note also that Dij := 0 when i=j.
 #####
 
-MoranI <- function(values, weights, alternative='two.sided'){
-  hyptest <- pmatch(alternative, c('two.sided', 'less', 'greater'))
-  if(is.na(alternative) || length(alternative) > 1){
-    stop("'alternative' must be an unambiguous abbreviation of one of the
-         following: 'two.sided', 'less', 'greater'")
-  }
+MoranI <- function(values, weights, alternative=c('two.sided', 'less', 'greater')){
+  hyptest <- match.arg(alternative)
   if(!is(weights, 'dist')){
     if (is(weights, 'matrix')){
       warning("'weights' is matrix rather than 'dist', attempting to convert...")
@@ -62,11 +58,11 @@ MoranI <- function(values, weights, alternative='two.sided'){
   }
   denom <- ifelse(retval$sd==0, 1, retval$sd)
   p <- NULL
-  if (hyptest == 1){
+  if (hyptest == "two.sided"){
     p <- 2*pnorm(abs(retval$observed - retval$expected) / denom, lower.tail=FALSE)
-  } else if (hyptest==2){
+  } else if (hyptest == "less"){
     p <- pnorm((retval$observed - retval$expected) / denom, lower.tail=TRUE)
-  } else {
+  } else { ## greater
     p <- pnorm((retval$observed - retval$expected) / denom, lower.tail=FALSE)
   }
   retval$p.value <- p

--- a/man/BlastSeqs.Rd
+++ b/man/BlastSeqs.Rd
@@ -5,35 +5,35 @@ Run BLAST queries from R
 }
 \description{
 Wrapper to run \href{https://blast.ncbi.nlm.nih.gov/Blast.cgi}{BLAST} queries using the commandline BLAST tool directly from R.
-Can operate on an \code{\link[Biostrings]{XStringSet}} or a \code{FASTA} file. 
+Can operate on an \code{\link[Biostrings]{XStringSet}} or a \code{FASTA} file.
 
-This function requires the BLAST+ commandline tools, which can be downloaded 
-\href{https://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastDocs&DOC_TYPE=Download}{here}.
+This function requires the BLAST+ commandline tools, which can be downloaded from
+\href{https://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastDocs&DOC_TYPE=Download}{https://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastDocs&DOC_TYPE=Download}.
 }
 \usage{
-BlastSeqs(seqs, BlastDB, 
+BlastSeqs(seqs, BlastDB,
               blastType=c('blastn', 'blastp', 'tblastn', 'blastx', 'tblastx'),
               extraArgs='', verbose=TRUE)
 }
 \arguments{
   \item{seqs}{
-    Sequence(s) to run BLAST query on. This can be either an 
+    Sequence(s) to run BLAST query on. This can be either an
     \code{\link[Biostrings]{XStringSet}} or a path to a FASTA file.
   }
   \item{BlastDB}{
-    Path to FASTA file in a pre-built BLAST Database. These can be built using either \code{\link{MakeBlastDb}} from R or
+    Character; path to FASTA file in a pre-built BLAST Database. These can be built using either \code{\link{MakeBlastDb}} from R or
     the commandline \code{makeblastdb} function from BLAST+. For more information
     on building BLAST DBs, see \href{https://www.ncbi.nlm.nih.gov/books/NBK569841/}{here}.
   }
   \item{blastType}{
-    Type of BLAST query to run. See 'Details' for more information on available types.
+    Character; type of BLAST query to run. See 'Details' for more information on available types.
   }
   \item{extraArgs}{
-    Additional arguments to be passed to the BLAST query
-    executed on the command line. This should be a single character string.
+    Character; additional arguments to be passed to the BLAST query
+    executed on the command line. This should be a single string. (Optional)
   }
   \item{verbose}{
-    Should output be displayed?
+    Logical; should output be displayed? (Optional, default \code{TRUE})
   }
 }
 \details{

--- a/man/BuiltInEnsembles.Rd
+++ b/man/BuiltInEnsembles.Rd
@@ -24,16 +24,14 @@ See the examples for how to train your own ensemble model.
 }
 
 \examples{
-## Training own ensemble method to avoid
-## using built-ins
+## Training own ensemble method to avoid using built-ins
+## defaults to built-ins when an ensemble isn't provided
 
 exData <- get(data("ExampleStreptomycesData"))
 ew <- EvoWeaver(exData$Genes[seq_len(50L)], MySpeciesTree=exData$Tree)
 datavals <- predict(ew, NoPrediction=TRUE, Verbose=interactive())
 
-# Make sure the actual values correspond to the right pairs!
-# This example just picks random numbers
-# Do not do this for your own models
+# Picking random numbers for demonstration purposes
 actual_values <- sample(c(0,1), nrow(datavals), replace=TRUE)
 datavals[,'y'] <- actual_values
 myModel <- glm(y~., datavals[,-c(1,2)], family='binomial')

--- a/man/CIDist_NullDist.Rd
+++ b/man/CIDist_NullDist.Rd
@@ -14,7 +14,7 @@ Simulated values of \link[=PhyloDistance-CI]{Clustering Information Distance} fo
 \details{
 Each column of the matrix corresponds to the distribution of distances between random trees with the given number of leaves. This begins at \code{CI_DISTANCE_INTERNAL[,1]} corresponding to 4 leaves, and ends at \code{CI_DISTANCE_INTERNAL[,197]} corresponding to 200 leaves. Distances begin at 4 leaves since there is only one unrooted tree with 1, 2, or 3 leaves (so the distance between any given tree with less than 4 leaves is always 0).
 
-Each row of the matrix corresponds to statistics for the given simulation set. The first row gives the minimum value, the next 9 give quantiles in \code{c(1\%, 5\%, 10\%, 25\%, 50\%, 75\%, 90\%, 95\%, 99\%)}, and the last three rows give the \code{max}, \code{mean}, and \code{sd} (resp.).
+Each row of the matrix corresponds to statistics for the given simulation set. The first row gives the minimum value, the next 9 give quantiles in \code{c(1\%, 5\%, 10\%, 25\%, 50\%, 75\%, 90\%, 95\%, 99\%)}, and the last three rows give the \code{max}, \code{mean}, and \code{sd} (respectively).
 }
 \source{
 Datafiles obtained from the \href{https://ms609.github.io/TreeDistData/index.html}{TreeDistData} package, published as part of Smith (2020).

--- a/man/DPhyloStatistic.Rd
+++ b/man/DPhyloStatistic.Rd
@@ -5,7 +5,7 @@
 D-Statistic for Binary States on a Phylogeny
 }
 \description{
-Calculates if a presence/absence pattern is random, Brownian, or neither with respect to a given phylogeny.
+Calculates if a presence/absence pattern is random, Brownian, or neither for a binary trait with respect to a given phylogeny.
 }
 \usage{
 DPhyloStatistic(dend, PAProfile, NumIter = 1000L)
@@ -16,18 +16,18 @@ DPhyloStatistic(dend, PAProfile, NumIter = 1000L)
   An object of class \code{\link{dendrogram}}
 }
   \item{PAProfile}{
-  A vector representing presence/absence of binary traits. See Details for more information.
+  A vector representing presence/absence of binary traits. See Details for information on supported input types.
 }
   \item{NumIter}{
-  Number of iterations to simulate for random permutation analysis.
+  Integer; Number of iterations to simulate for random permutation analysis.
 }
 }
 \details{
 This function implements the D-Statistic for binary traits on a phylogeny, as introduced in Fritz and Purvis (2009). The statstic is the following ratio:
 \deqn{\frac{D_{obs} - D_b}{D_r - D_b}}
-Here \eqn{D_{obs}} is the D value for the input data, \eqn{D_b} is the value under simulated Brownian evolution, and \eqn{D_r} is the value under random permutation of the input data. The D value measures the sum of sister clade differences in a phylogeny weighted by branch lengths. A score close to 1 indicates phylogenetically random distribution, and a score close to 0 indicates the trait likely evolved under Brownian motion. Scores can fall outside this range; these scores are only intended as benchmark points on the scale. See the original paper cited in References for more information.
+Here \eqn{D_{obs}} is the D value for the input data, \eqn{D_b} is the value under simulated Brownian evolution, and \eqn{D_r} is the value under random permutation of the input data. The D value measures the sum of sister clade differences in a phylogeny weighted by branch lengths. A score close to 1 indicates phylogenetically random distribution, and a score close to 0 indicates the trait likely evolved under Brownian motion. Scores can fall outside this range; these scores are only intended as benchmark points on the scale. See the Value section or the original paper cited in References for more information.
 
-The input \code{PAProfile} supports a number of formatting options:
+The input parameter \code{PAProfile} supports a number of formatting options:
 \itemize{
   \item{Character vector, where each element is a label of the dendrogram. Presence in the character vector indicates presence of the trait in the corresponding label.}
   \item{Integer vector of length equivalent to the number of leaves, comprised of 0s and 1s. 0 indicates absence in the corresponding leaf, and 1 indicates presence.}
@@ -37,7 +37,13 @@ The input \code{PAProfile} supports a number of formatting options:
 See Examples for a demonstration of each case.
 }
 \value{
-Returns a numerical value. Values close to 0 indicate random distribution, and values close to 1 indicate a Brownian distribution.
+Returns a numerical value with the following cases:
+\itemize{
+\item{Value less than 0: the trait is more phylogenetically concentrated than expected by chance ("extremely clumped")}
+\item{Value close to 0: the trait is as phylogenetically concetrated as expected if it had evolved by Brownian motion}
+\item{Value close to 1: the trait is as phylogenetically concetrated as expected under a random distribution}
+\item{Value greater than 1: the trait is less phylogenetically concentrated than expected under a random distribution ("overdispersed")}
+}
 }
 \references{
 Fritz S.A. and Purvis A. \emph{Selectivity in Mammalian Extinction Risk and Threat Types: a New Measure of Phylogenetic Signal Strength in Binary Traits.} Conservation Biology, 2010. \bold{24}(4):1042-1051.

--- a/man/DecisionTree-class.Rd
+++ b/man/DecisionTree-class.Rd
@@ -23,7 +23,7 @@ DecisionTree objects comprising random forest models generated with \code{\link{
   an object of class \code{DecisionTree} to plot.
   }
   \item{plotGain}{
-  logical; should the Gini gain or decrease in sum of squared error be plotted for each decision point of the tree?
+  Logical; Determines if the Gini gain (for classification) or decrease in sum of squared error (for regression) should be plotted for each decision point of the tree. If \code{FALSE}, only plots the variable threshold for each decision point.
   }
   \item{...}{
   For \code{plot}, further arguments passed to \code{\link{plot.dendrogram}} and \code{\link{text}}. Arguments prefixed with \code{"text."} (e.g., \code{text.cex}) will be passed to \code{text}, and all other arguments are passed to \code{plot.dendrogram}.

--- a/man/EstimRearrScen.Rd
+++ b/man/EstimRearrScen.Rd
@@ -3,7 +3,7 @@
 \alias{EstimateRearrangementScenarios}
 
 \title{
-Estimate Genome Rearrangement Events with Double Cut and Join Operations
+Estimate Genome Rearrangement Scenarios with Double Cut and Join Operations
 }
 \description{
 Take in a \code{\link[=Synteny-class]{Synteny}} object and return predicted rearrangement events.
@@ -12,87 +12,82 @@ Take in a \code{\link[=Synteny-class]{Synteny}} object and return predicted rear
 EstimRearrScen(SyntenyObject, NumRuns = -1,
                 Mean = FALSE, MinBlockLength = -1,
                 Verbose = TRUE)
-                
+
 }
 
 \arguments{
   \item{SyntenyObject}{
-  \code{\link[=Synteny-class]{Synteny}} object, as obtained from running \code{\link{FindSynteny}}. 
+  \code{\link[=Synteny-class]{Synteny}} object, as obtained from running \code{\link{FindSynteny}}.
   Expected input is unichromosomal sequences, though multichromosomal sequences are supported.
   }
   \item{NumRuns}{
-  Numeric; Number of times to simulate scenarios. The default value of -1 (and all non-positive
-  values) runs each analysis for \eqn{\sqrt b} iterations, where \code{b} is the number of unique
-  breakpoints.
+  Numeric; The number of scenarios to simulate. The default value of -1 corresponds to \eqn{\sqrt b} scenarios, where \eqn{b} is the number of unique
+  breakpoints in the Synteny object.
   }
   \item{Mean}{
-  Logical; If TRUE, returns the mean number of inversions and transpositions found. If FALSE,
-  returns the scenario corresponding to the minimum total number of operations 
-  across all runs. This parameter only affects the number of inversions and 
-  transpositions reported; the specific scenario returned is one of the runs that 
-  resulted in a minimum value.
+  Logical; Indicates whether to return the mean (\code{TRUE}) or minimum (\code{FALSE}) number of inversions and transpositions found across all runs.
   }
   \item{MinBlockLength}{
-  Numeric; Minimum size of syntenic blocks to use for analysis. The default value accepts all blocks.
-  Set to a larger value to ignore sections of short mutations that could be the 
+  Numeric; Minimum size of syntenic blocks to use for analysis. The default value of -1 accepts all blocks.
+  Set to a larger value to ignore sections of short mutations that could be the
   result of SNPs or other small-scale mutations.
   }
   \item{Verbose}{
-  Logical; indicates whether or not to display a progress bar and print the time difference upon completion.
+  Logical; If \code{TRUE}, displays a progress bar and prints the time difference upon completion.
   }
 }
 \details{
 \code{EstimRearrScen} is an implementation of the Double Cut and Join
-(DCJ) method for analyzing large scale mutation events. 
+(DCJ) method for analyzing large scale mutation events.
 
 The DCJ model is commonly used to model genome rearrangement operations. Given a genome,
-we can create a connected graph encoding the order of conserved genomic regions. 
+we can create a connected graph encoding the order of conserved genomic regions.
 Each syntenic region is split into two nodes, with one encoding the beginning and one encoding the end
 (beginning and end defined relative to the direction of transcription). Each node
 is then connected to the two nodes it is adjacent to in the genome.
 
 For example, given a genome with 3 syntenic regions \eqn{a-b-c} such that \eqn{b}
-is transcribed in the opposite direction relative to \eqn{a,c}, our graph would consist 
+is transcribed in the opposite direction relative to \eqn{a,c}, our graph would consist
 of nodes and edges \eqn{a1-a2-b2-b1-c1-c2}.
 
 Given two genomes, we derive syntenic regions between the two samples and then construct
-two of these graph structures. A DCJ operation is one that cuts two connections 
+two of these graph structures. A DCJ operation is one that cuts two connections
 of a common color and creates two new edges. The goal of the DCJ model is to rearrange
 the graph of the first genome into the second genome using DCJ operations. The
 DCJ distance is defined as the minimum number of DCJ operations to transform one
 graph into another.
 
 It can be easily shown that inversions can be performed with a single DCJ operation,
-and block interchanges/order rearrangements can be performed with a sequence of 
-two DCJ operations. DCJ distance defines a metric space, and prior work has 
-demonstrated algorithms for fast computation of the DCJ distance. 
+and block interchanges/order rearrangements can be performed with a sequence of
+two DCJ operations. DCJ distance defines a metric space, and prior work has
+demonstrated algorithms for fast computation of the DCJ distance.
 
-However, DCJ distance inherently incentivizes inversions over block interchanges 
+However, DCJ distance inherently incentivizes inversions over block interchanges
 due to the former requiring half as many DCJ operations. This is a strong assumption,
 and there is no evidence to support gene order rearrangements occuring half as often
 as gene inversions.
 
-This implementation incentivizes minimum number of total events rather than total number of DCJs. 
+This implementation incentivizes minimum number of \bold{events} rather than number of DCJs.
 As the search space is large and multiple sequences of events can be equally parsimonious,
 this algorithm computes multiple scenarios with random sequences of operations to
-try to find the minimum amount of events. Users can choose to receive the best found
-solution or the mean number of events from all solutions.
+try to find the minimum. The \code{Mean} parameter controls if the function returns the best found
+solution (\code{Mean=FALSE}) or the mean number of events from all solutions (\code{Mean=TRUE}).
 }
 \value{
-An \emph{NxN} matrix of lists with the same shape as the input Synteny object. This is 
+An \emph{NxN} matrix of lists with the same shape as the input Synteny object. This is
 wrapped into a \code{GenRearr} object for pretty printing.
 
-The diagonal corresponds to total sequence length of the corresponding genome. 
+The diagonal corresponds to total sequence length of the corresponding genome.
 
 In the upper triangle, entry
 \code{[i,j]} corresponds to the percent hits between genome \code{i} and genome \code{j}.
 In the lower triangle, entry \code{[i,j]} contains a List object with 5 properties:
 \itemize{
 \item \code{$Inversions} and \code{$Transpositions} contain the (Mean/min) number of estimated inversions
-and transpositions (resp.) between genome \code{i} and genome \code{j}. 
+and transpositions (resp.) between genome \code{i} and genome \code{j}.
 \item \code{$pct_hits}
-contains percent hits between the genomes. 
-\item \code{$Scenario} shows the sequence of events corresponding to the minimum 
+contains percent hits between the genomes.
+\item \code{$Scenario} shows the sequence of events corresponding to the minimum
 rearrangement scenario found. See below for details.
 \item \code{$Key} provides a mapping between syntenic blocks and genome positions.
 See below for details.
@@ -103,26 +98,26 @@ showing the number of chromosomes and the lower triangle displaying \code{xI,yT}
 \code{x,y} the number of inversions and transpositions (resp.) between the
 corresponding entries.
 
-The \code{$Scenario} entry describes a sequences of steps to rearrange one genome 
+The \code{$Scenario} entry describes a sequences of steps to rearrange one genome
 into another, as found by this algorithm. The goal of the DCJ model is to rearrange
 the second genome into the first. Thus, with \code{N} syntenic regions total, we can
-arbitrarily choose the syntenic blocks in genome 1 to be ordered \code{1,2,...,N}, 
+arbitrarily choose the syntenic blocks in genome 1 to be ordered \code{1,2,...,N},
 and then have genome 2 numbers relative to that.
 
-As an example, suppose genome 1 has elements \code{A B E(r) G} and genome 2 has elements 
+As an example, suppose genome 1 has elements \code{A B E(r) G} and genome 2 has elements
 \code{E B(r) A(r) G}, with X(r) denoting block X has reversed direction of transcription.
 We can then arbitrarily assign blocks to numbers such that genome 1 is \code{(1 2 3 4)}
 and genome 2 is \code{(3 -2 -1 4)}, where a negative indicates reversed direction of transcription
 relative to the corresponding syntenic block in genome 1.
 
 Each entry in \code{$Scenario} details an operation, the result after that operation,
-and the number of blocks involved in the operation. If we reversed the middle two 
+and the number of blocks involved in the operation. If we reversed the middle two
 entries of genome 2, the entry in \code{$Scenario} would be:
 
 \code{inversion: 3 1 2 4 \{ 2 \}}
 
-Here we inverted the whole block \code{(-2 -1)} into \code{(1 2)}. We could then 
-finish the rearrangement by performing a transposition to move block 3 between 
+Here we inverted the whole block \code{(-2 -1)} into \code{(1 2)}. We could then
+finish the rearrangement by performing a transposition to move block 3 between
 2 and 4. The entries of \code{$Scenario} in this case would be the following:
 
 \code{Original: 3 -2 -1 4}
@@ -131,13 +126,13 @@ finish the rearrangement by performing a transposition to move block 3 between
 
 \code{block interchange: 1 2 3 4 \{ 3 \}}
 
-Step 1 is the original state of genome 2, step 2 inverts 2 elements to arrive at 
-\code{(3 1 2 4)}, and then step 3 moves one element to arrive at \code{(1 2 3 4)}. 
+Step 1 is the original state of genome 2, step 2 inverts 2 elements to arrive at
+\code{(3 1 2 4)}, and then step 3 moves one element to arrive at \code{(1 2 3 4)}.
 
 It is important to note that the numbered genomic regions in \code{$Scenario} are not genes,
 they are blocks of conserved syntenic regions between the genomes. These blocks may not match
 up with the original blocks from the Synteny object, since some are combined during
-pre-processing to expedite calculations. 
+pre-processing to expedite calculations.
 
 \code{$Key} is a mapping between these numbered regions and the original genomic regions.
 This is a 5 column matrix with the following columns (in order):
@@ -146,7 +141,7 @@ This is a 5 column matrix with the following columns (in order):
   on genome 1.
   \item \code{start2}: Same as \code{start1}, but for genome 2
   \item \code{length}: Length of block, in nucleotides
-  \item \code{rel_direction_on_2}: 1 if the blocks have the same transcriptonal direction on both 
+  \item \code{rel_direction_on_2}: 1 if the blocks have the same transcriptonal direction on both
   genomes, and 0 if the direction is reversed in genome 2
   \item \code{index1}: Label of the genetic region used in \code{$Scenario} output
 }

--- a/man/EstimateExoLabel.Rd
+++ b/man/EstimateExoLabel.Rd
@@ -16,29 +16,29 @@ EstimateExoLabel(num_v, avg_degree=2,
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{num_v}{
-Approximate number of total unique nodes in the network.
+Integer; approximate number of total unique nodes in the network.
 }
 
 \item{avg_degree}{
-Average degree of each node in the network.
+Numeric; average degree of nodes in the network (i.e., the average number of neighbors for each node)
 }
 
 \item{is_undirected}{
-Logical indicating whether edges are directed or undirected. Undirected edges consume twice as much disk space internally because they need to be recorded twice.
+Logical; indicates whether edges are undirected (\code{TRUE}) or directed (\code{FALSE}). Undirected edges consume twice as much disk space internally because they need to be recorded twice.
 }
 
 \item{num_edges}{
-Approximate total number of edges in the network.
+Integer; approximate total number of edges in the network.
 }
 
 \item{node_name_length}{
-Approximate average length of each node name, in characters.
+Integer; approximate average length of each node name, in characters.
 }
 }
 \details{
-This function provides a rough estimate of the total disk space required to run \code{\link{ExoLabel}} for a given input network. \code{avg_degree} and \code{num_edges} need not both be specified. The function prints out the estimated size of the original edgelist files, the estimated disk space and RAM to be consumed by \code{\link{ExoLabel}}, and the approximate ratio of disk space relative to the original file.
+This function provides a rough estimate of the total disk space required to run \code{\link{ExoLabel}} for a given input network. Only one of \code{avg_degree} and \code{num_edges} must be provided. The function prints out the estimated size of the original edgelist files, the estimated disk space and RAM to be consumed by \code{\link{ExoLabel}}, and the approximate ratio of disk space relative to the original file.
 
-\code{node_name_length} specifies the average length of the node names--since the names themselves must be stored on disk, this contributes to the overall size. For relatively short node names (1-16 characters) this has a negligible impact on overall disk consumption, though it may impact the worst-case RAM consumption. Expected RAM consumption is determined by the average prefix length a random pair of vertex labels have in common, and should be closer to the minimum usage in most scenarios (see \code{\link{ExoLabel}} for more details on this).
+\code{node_name_length} specifies the average length of the node names--since the names themselves must be stored on disk, this contributes to the overall size. For relatively short node names (1-16 characters) this has a negligible impact on overall disk consumption, though it may impact the worst-case RAM consumption. Expected RAM consumption is determined by the average prefix length a random pair of vertex labels have in common, and should be closer to the minimum usage in most scenarios (see \code{\link{ExoLabel}} for more details).
 }
 \value{
 Invisibly returns a vector of length six, showing the estimated RAM consumption, estimated input edgelist file size, estimated disk consumption using in-place sort (\code{use_fast_sort=FALSE}), estimated disk consumption using fast sort (\code{use_fast_sort=TRUE}), estimated final file size, and ratio of the input file size to total ExoLabel disk usage. All values denote bytes.

--- a/man/EvoWeaver-GOPreds.Rd
+++ b/man/EvoWeaver-GOPreds.Rd
@@ -69,5 +69,5 @@ Moran, P. A. P., \emph{Notes on Continuous Stochastic Phenomena}. Biometrika, 19
 
 \link[=EvoWeaver-PSPreds]{EvoWeaver Phylogenetic Structure Predictors}
 
-\link[=EvoWeaver-SLPreds]{EvoWeaver Sequence-Level Predictors}
+\link[=EvoWeaver-SLPreds]{EvoWeaver Sequence Level Predictors}
 }

--- a/man/EvoWeaver-GOPreds.Rd
+++ b/man/EvoWeaver-GOPreds.Rd
@@ -22,8 +22,8 @@ regions within the genome.
 }
 
 \details{
-All distance matrix methods require a \code{EvoWeaver} object initialized
-with gene locations using the a four number code. See \code{\link{EvoWeaver}} for more information on input data types.
+All distance matrix methods require an \code{EvoWeaver} object initialized
+with gene locations using a four number code. See \code{\link{EvoWeaver}} for more information on input data types.
 
 The built-in \code{GeneDistance} examines relative location of genes within genomes
 as evidence of interaction. For a given pair of genes, the score is given by

--- a/man/EvoWeaver-PPPreds.Rd
+++ b/man/EvoWeaver-PPPreds.Rd
@@ -60,11 +60,11 @@ with identical extant patterns is collapsed to a single leaf.
 relative to the total time each individual gene occurs, based on ancestral states inferred
 with Fitch parsimony.
 
-\code{PAPV} calculates a p-value for PA profiles using Fisher's Exact Test. The returned score is provided as \code{1-p_value} so that larger scores indicate more significance, and smaller scores indicate less significance. This rescaling is consistent with the other similarity metrics in \code{EvoWeaver}. This can be used with \code{ExtantJaccard}, \code{Hamming}, or \code{GLMI} to weight raw scores by statistical significance.
+\code{PAPV} calculates a p-value for P/A profiles using Fisher's Exact Test. The returned score is provided as \code{1-p_value} so that larger scores indicate more significance, and smaller scores indicate less significance. This rescaling is consistent with the other similarity metrics in \code{EvoWeaver}. This can be used with \code{ExtantJaccard}, \code{Hamming}, or \code{GLMI} to weight raw scores by statistical significance.
 
 \code{ProfDCA} uses the direct coupling analysis algorithm introduced by
-Weigt et al. (2005) to determine direct information between PA profiles.
-This approach has been validated on PA profiles in Fukunaga and Iwasaki (2022),
+Weigt et al. (2005) to determine direct information between P/A profiles.
+This approach has been validated on P/A profiles in Fukunaga and Iwasaki (2022),
 though the implementation in \code{EvoWeaver} forsakes the persistent contrasive divergence method in favor of the the algorithm from
 Lokhov et al. (2018) for increased speed and exact solutions. Note that this algorithm is still extremely slow relative to the other methods despite the aforementioned runtime improvements.
 
@@ -114,5 +114,5 @@ Weigt, M., et al., \emph{Identification of direct residue contacts in protein-pr
 
 \link[=EvoWeaver-GOPreds]{EvoWeaver Gene Organization Predictors}
 
-\link[=EvoWeaver-SLPreds]{EvoWeaver Sequence-Level Predictors}
+\link[=EvoWeaver-SLPreds]{EvoWeaver Sequence Level Predictors}
 }

--- a/man/EvoWeaver-PPPreds.Rd
+++ b/man/EvoWeaver-PPPreds.Rd
@@ -19,7 +19,7 @@ methods and algorithms. Phylogenetic Profiling (PP) methods examine conservation
 of gain/loss events within orthology groups using phylogenetic profiles
 constructed from presence/absence patterns.
 
-\code{predict.EvoWeaver} currently supports nine PP methods:
+\code{predict.EvoWeaver} currently supports ten PP methods:
 \itemize{
   \item \code{'ExtantJaccard'}
   \item \code{'Hamming'}
@@ -41,16 +41,16 @@ with any input type. See \code{\link{EvoWeaver}} for more information on input d
 When \code{Method='Ensemble'} or \code{Method="PhylogeneticProfiling"}, EvoWeaver uses
 methods \code{GLMI}, \code{GLDistance}, \code{PAJaccard}, and \code{PAOverlap}.
 
-All of these methods use presence/absence (PA) profiles, which are binary
+These methods use presence/absence (P/A) profiles, which are binary
 vectors such that 1 implies the corresponding genome has that particular
 gene, and 0 implies the genome does not have that particular gene.
 
 Methods \code{Hamming} and \code{ExtantJaccard} use Hamming and Jaccard distance
-(respectively) of PA profiles to determine overall score.
+(respectively) of P/A profiles to determine overall score.
 
 \code{GLMI} uses mutual information of gain/loss (G/L) vectors to determine
 score, employing a weighting scheme such that concordant gains/losses give positive information,
-discordant gains/losses give negative information, and events that do not cooccur with a gain/loss
+discordant gains/losses give negative information, and events that do not co-occur with a gain/loss
 in the other gene group give no information.
 
 \code{PAJaccard} calculates the centered Jaccard index of P/A profiles, where each clade

--- a/man/EvoWeaver-PSPreds.Rd
+++ b/man/EvoWeaver-PSPreds.Rd
@@ -92,7 +92,7 @@ Sato, T., et al., \emph{Partial correlation coefficient between distance matrice
 
 \link[=EvoWeaver-GOPreds]{EvoWeaver Gene Organization Predictors}
 
-\link[=EvoWeaver-SLPreds]{EvoWeaver Sequence-Level Predictors}
+\link[=EvoWeaver-SLPreds]{EvoWeaver Sequence Level Predictors}
 
 \code{\link{PhyloDistance}}
 }

--- a/man/EvoWeaver-PSPreds.Rd
+++ b/man/EvoWeaver-PSPreds.Rd
@@ -32,7 +32,7 @@ coefficient of the upper triangle of the two corresponding matrices.
 
 Experimental analysis has shown data in the upper triangle is heavily
 redundant and rapidly overwhelms available system memory. Previous work
-has incorporated dimensionality reduction such as SVD to reduce the dimensionality
+has incorporated dimensionality reduction such as Singular Value Decomposition (SVD) to reduce the dimensionality
 of the data, but this prevents parallelization of the data and doesn't solve memory
 issues (since SVD takes as input the entire matrix with columns corresponding to upper triangle values). \code{EvoWeaver} instead uses a seeded random projection
 following Achlioptas (2001) to reduce the dimensionality of the data in a
@@ -48,8 +48,8 @@ The built-in \code{RPContextTree} method implements a species tree correction, a
 
 The \code{TreeDistance} method uses phylogenetic tree distance to quantify differences between gene trees. This method implements a number of metrics and groups them together to improve overall runtime. The default tree distance method is normalized Robinson-Foulds distance due to its lower computational complexity. Other methods can be specified using the \code{TreeMethods} argument, which expects a character vector containing one or more of the following:
 \itemize{
-\item \code{"CI"}: \link[=CIDist]{Clustering Information Distance}
 \item \code{"RF"}: \link[=RFDist]{Robinson-Foulds Distance}
+\item \code{"CI"}: \link[=CIDist]{Clustering Information Distance}
 \item \code{"JRF"}: \link[=JRFDist]{Jaccard-Robinson-Foulds Distance}
 \item \code{"Nye"}: \link[=JRFDist]{Nye Similarity}
 \item \code{"KF"}: \link[=KFDist]{Kuhner-Felsenstein Distance}

--- a/man/EvoWeaver-SLPreds.Rd
+++ b/man/EvoWeaver-SLPreds.Rd
@@ -5,11 +5,11 @@
 \alias{Ancestral.EvoWeaver}
 \docType{data}
 \title{
-Sequence-Level Predictions for EvoWeaver
+Sequence Level Predictions for EvoWeaver
 }
 \description{
 \code{EvoWeaver} incorporates four classes of prediction, each with multiple
-methods and algorithms. Sequence-Level (SL) methods examine conservation of patterns in sequence data, commonly exhibited due to physical interactions
+methods and algorithms. Sequence Level (SL) methods examine conservation of patterns in sequence data, commonly exhibited due to physical interactions
 between proteins.
 
 \code{predict.EvoWeaver} currently supports three SL methods:
@@ -21,8 +21,8 @@ between proteins.
 }
 
 \details{
-All residue methods require a \code{EvoWeaver} object initialized
-with \code{dendrogram} objects and ancestral states. See \code{\link{EvoWeaver}} for more information on input data types.
+Sequence Level methods require a \code{EvoWeaver} object initialized
+with \code{dendrogram} objects and sequence information stored in the leaves. See \code{\link{EvoWeaver}} for more information on input data types.
 
 When \code{Method='Ensemble'} or \code{Method="SequenceLevel"}, EvoWeaver uses
 methods \code{SequenceInfo} and \code{GeneVector}. The argument \code{useDNA} switches between interpreting sequences as DNA or AA sequences.
@@ -37,7 +37,7 @@ The \code{GeneVector} method uses the natural vector encoding method introduced 
               \qquad\qquad\qquad n_{AA},n_{AC},\dots,n_{TT},\\
               \qquad\qquad\qquad\quad\;\; n_{AAA},n_{AAC},\dots,n_{TTT})}
 
-Here \eqn{n_X} is the raw total count of nucleotide \eqn{X} (or di/trinucleotide). For single nucleotides, we also calculate \eqn{\mu_X}, the mean location of nucleotide \eqn{X}, and \eqn{D_2^X}, the second moment of the location of nucleotide \eqn{X}. The overall natural vector for a COG is calculated as the normalized mean vector from the natural vectors of all component gene sequences. Interaction scores are computed using Pearson's R between each COG's natural vector. These di/trinucleotide counts are by default excluded, but can be included using the \code{extended=TRUE} argument. Using the extended counts has shown minimal increased accuracy at the cost of slower runtime in benchmarking.
+Here \eqn{n_X} is the raw total count of nucleotide \eqn{X} (or di/trinucleotide). For single nucleotides, we also calculate \eqn{\mu_X}, the mean location of nucleotide \eqn{X}, and \eqn{D_2^X}, the second moment of the location of nucleotide \eqn{X}. The overall natural vector for a Cluster of Orthologous Genes (COG) is calculated as the normalized mean vector from the natural vectors of all component gene sequences. Interaction scores are computed using Pearson's R between each COG's natural vector. These di/trinucleotide counts are by default excluded, but can be included using the \code{extended=TRUE} argument. Using the extended counts has shown minimal increased accuracy at the cost of slower runtime in benchmarking.
 
 The \code{Ancestral} method calculates coevolution by looking at correlation of residue mutations near the leaves of each respective gene tree.
 }

--- a/man/EvoWeaver.Rd
+++ b/man/EvoWeaver.Rd
@@ -63,7 +63,7 @@ Case (3) expects gene trees for each gene, with labeled leaves corresponding to 
 
 \emph{Whenever possible, provide a full set of \code{dendrogram} objects with leaf labels in form (2). This will allow the most algorithms to run. What follows is a more detailed description of which inputs allow which algorithms.}
 
-EvoWeaver requires input of scenario (3) to use distance matrix methods, and requires input of scenario (2) (or (3) with leaves labeled according to (2)) for gene organization analyses. Sequence-level methods require dendrograms with sequence information included as the \code{state} attribute in each leaf node.
+EvoWeaver requires input of scenario (3) to use distance matrix methods, and requires input of scenario (2) (or (3) with leaves labeled according to (2)) for gene organization analyses. Sequence Level methods require dendrograms with sequence information included as the \code{state} attribute in each leaf node.
 
 Note that ALL entries must belong to the same category--a combination of character vectors and dendrograms is not allowed.
 

--- a/man/EvoWeaver.Rd
+++ b/man/EvoWeaver.Rd
@@ -5,7 +5,7 @@
 \alias{SpeciesTree}
 \alias{SpeciesTree.EvoWeaver}
 \title{
-EvoWeaver: Predicting Protein Functional Association Networks
+EvoWeaver: Identifying Gene Functional Associations from Coevolutionary Signals
 }
 \description{
 EvoWeaver is an S3 class with methods for predicting functional association using
@@ -27,27 +27,27 @@ An object of class \code{'dendrogram'} representing the overall species tree for
 the list provided in \code{ListOfData}.
 }
 \item{NoWarn}{
-Several algorithms depend on having certain data. When a \code{EvoWeaver} object is initialized, it automatically selects which algorithms can be used given the input data. By default, EvoWeaver will notify the user of algorithms that cannot be used with warnings. Setting \code{NoWarn=TRUE} will suppress these messages.
+Logical; If \code{FALSE}, displays warnings corresponding to which algorithms are unavailable for given input data format (see Details for more information).
 }
 \item{ew}{
-An object of class \code{EvoWeaver}
+An object of class \code{EvoWeaver}.
 }
 \item{Verbose}{
-Should output be displayed when calculating species tree?
+Logical; If \code{TRUE}, displays output when calculating species tree.
 }
 \item{Processors}{
-Number of processors to use. Set to \code{NULL} to automatically use the maximum
+Integer; The number of processors to use. Set to \code{NULL} to automatically use the maximum
 amount of processors.
 }
 }
 \details{
-EvoWeaver expects input data to be a list. All entries must be one of the following:
+EvoWeaver expects input data to be a list. All entries must be one of the following cases:
 \enumerate{
   \item{
     \code{ListOfData[[i]] = c('ID#1', 'ID#2', ..., 'ID#k')}
   }
   \item{
-    \code{ListOfData[[i]] = c('i1_d1_s1_p1', 'i2_d2_s2_p2', ..., 'ik_dk_sk_pk') }}
+    \code{ListOfData[[i]] = c('g1_d1_s1_p1', 'g2_d2_s2_p2', ..., 'gk_dk_sk_pk') }}
 
   \item{
   \code{ListOfData[[i]] = dendrogram(...)}
@@ -55,7 +55,7 @@ EvoWeaver expects input data to be a list. All entries must be one of the follow
 }
 In (1), each ID#i corresponds to the unique identifier for genome #i. For entry #j in the list, the presence of 'ID#i' means genome #i has an ortholog for gene/protein #j.
 
-Case (2) is the same as (1), just with the formatting of names slightly different. Each entry is of the form \code{i_d_p}, where \code{i} is the unique identifier for the genome, \code{d} is which chromosome the ortholog is located, \code{s} indicates whether the gene is on the forward or reverse strand, and \code{p} is what position the ortholog appears in on that chromosome. \code{p} must be a \code{numeric}. \code{s} must be \code{0} or \code{1}, corresponding to whether the gene is on the forward or reverse strand. Whether \code{0} denotes forward or reverse is inconsequential as long as the scheme is consistent. \code{i,d} can be any value as long as it doesn't contain an underscore (\code{'_'}).
+Case (2) is the same as (1), just with the formatting of names slightly different. Each entry is of the form \code{g_d_p}, where \code{g} is the unique identifier for the genome, \code{d} is which chromosome the ortholog is located, \code{s} indicates whether the gene is on the forward or reverse strand, and \code{p} is what position the ortholog appears in on that chromosome. \code{p} must be a \code{numeric}. \code{s} must be \code{0} or \code{1}, corresponding to whether the gene is on the forward or reverse strand. Whether \code{0} denotes forward or reverse is inconsequential as long as the scheme is consistent. \code{g,d} can be any value as long as they don't contain an underscore (\code{'_'}).
 
 Case (3) expects gene trees for each gene, with labeled leaves corresponding to each source genome. If \code{ListOfData} is in this format, taking \code{labels(ListOfData[[i]])} should produce a character vector that matches the format of one of the previous cases.
 

--- a/man/EvoWeb.Rd
+++ b/man/EvoWeb.Rd
@@ -5,17 +5,17 @@ EvoWeb: Predictions from EvoWeaver
 }
 \docType{data}
 \description{
-EvoWeb objects are outputted from \code{\link{predict.EvoWeaver}}.
+EvoWeb objects can be returned from \code{\link{predict.EvoWeaver}}.
 
 This class wraps the \code{\link{simMat}} object with some other diagnostic
 information intended to help interpret the output of \code{\link{EvoWeaver}}
-predictions..
+predictions.
 }
 
 \details{
 \code{\link{predict.EvoWeaver}} returns a \code{EvoWeb} object, which bundles some methods
 to make formatting and printing of results slightly nicer. This currently
-only implements a \code{plot} function, but future functionality is in the works.
+only implements a \code{plot} function.
 }
 \format{
 An object of class \code{"EvoWeb"}, which inherits from \code{"simMat"}.
@@ -41,7 +41,8 @@ exData <- get(data("ExampleStreptomycesData"))
 # Subset isn't necessary but is faster for a working example
 ew <- EvoWeaver(exData$Genes[1:10])
 
-evoweb <- predict(ew, Method='ExtantJaccard')
+# default return value is a data.frame (recommended for most users)
+evoweb <- predict(ew, Method='ExtantJaccard', ReturnDataFrame=FALSE)
 
 # print out results as an adjacency matrix
 print(evoweb)

--- a/man/ExampleStreptomycesData.Rd
+++ b/man/ExampleStreptomycesData.Rd
@@ -15,7 +15,7 @@ Data from \emph{Streptomyces} species to test \code{\link{EvoWeaver}} functional
 }
 \details{
 This dataset contains a number of Clusters of Orthologous Genes (COGs) and a species
-tree for use with EvoWeaver. This dataset showcases an example of using EvoWeaver with
+tree for use with EvoWeaver. This dataset showcases an example using EvoWeaver with
 a list of vectors. Entries in each vector are formatted correctly for use with
 co-localization prediction. Each COG \code{i} contains entries of the form
 \code{a_b_c}, indicating that the gene was found in genome \code{a} on chromosome

--- a/man/ExoLabel.Rd
+++ b/man/ExoLabel.Rd
@@ -5,14 +5,14 @@
 ExoLabel: Out of Memory Fast Label Propagation
 }
 \description{
-Runs Fast Label Propagation using disk space for constant memory complexity.
+Detects communities in networks with Fast Label Propagation using disk space to drastically reduce memory complexity.
 }
 \usage{
 ExoLabel(edgelistfiles,
               outfile=tempfile(),
               mode=c("undirected", "directed"),
               add_self_loops=FALSE,
-              attenuation_power=1,
+              attenuation=TRUE,
               ignore_weights=FALSE,
               iterations=0L,
               return_table=FALSE,
@@ -25,84 +25,86 @@ ExoLabel(edgelistfiles,
 %- maybe also 'usage' for other objects documented here.
 \arguments{
 \item{edgelistfiles}{
-Character vector of files to be processed. Each entry should be a machine-interpretable path to an edgelist file. See Details for expected format.
+Character; vector of files to be processed. Each entry should be a machine-interpretable path to an edgelist file. See Details for expected format.
 }
 
 \item{outfile}{
-File to write final clusters to. Optional, defaults to a temporary file. Can be set to a vector of filepaths to run multiple clusterings (see Details).
+Character; File to write final clusters to. Can be set to a vector of filepaths to run multiple clusterings (see Details).
 }
 
 \item{mode}{
-String specifying whether edges should be interpreted as undirected (default) or directed. Can be "undirected", "directed", or an unambiguous abbreviation.
+Character; Specifies whether edges should be interpreted as undirected (default) or directed. Can be "undirected", "directed", or an unambiguous abbreviation.
 }
 
 \item{add_self_loops}{
-Should self loops be added to the network? If \code{TRUE}, adds self loops of weight 1.0 to all vertices. If set to numeric value \code{w}, adds self loops of weight \code{w} to all nodes. Can also be set to a vector when running multiple clusterings (see Details).
+Logical or Numeric; Determines if self loops should be added to the network. If \code{TRUE}, adds self loops of weight 1.0 to all vertices. If set to numeric value \code{w}, adds self loops of weight \code{w} to all nodes. Can also be set to a vector when running multiple clusterings (see Details).
 }
 
-\item{attenuation_power}{
-Controls rate of dynamic scaling for label-hop attenuation. Defaults to 1, set to 0 to disable label-hop attenuation. See "Algorithm Convergence" for more information on this parameter. Can also be set to a vector when running multiple clusterings (see Details).
+\item{attenuation}{
+Logical or Numeric; Determines if label-hop attenuation should be used. If \code{TRUE}, uses attenuation to prevent single clusters from dominating results. Can also be set to a numeric to influence the strength of attenuation. See "Algorithm Convergence" for more information on this parameter. Can also be set to a vector when running multiple clusterings (see Details).
 }
 
 \item{ignore_weights}{
-Should weights be ignored? If \code{TRUE}, all edges will be treated as an edge of weight 1. Must be set to \code{TRUE} if any of \code{edgelistfiles} are two-column tables (start->end only, lacking a weights column).
+Logical; Determines if weights should be ignored. If \code{TRUE}, all edges will be treated as an edge of weight 1. Must be set to \code{TRUE} if any of \code{edgelistfiles} are two-column tables (start->end only, lacking a weights column).
 }
 
 \item{iterations}{
-Maximum number of times to process each node. If set to zero or \code{NULL}, automatically uses the square root of the max node degree. See "Algorithm Convergence" for more information.
+Integer; Maximum number of times to process each node. If set to zero or \code{NULL}, automatically uses the square root of the max node degree. See "Algorithm Convergence" for more information.
 }
 
 \item{return_table}{
-Should result of clustering be returned as a file, or a \code{data.frame} object? If \code{FALSE}, returns a character vector corresponding to the path of \code{outfile}. If \code{TRUE}, parses \code{outfile} using \code{\link{read.table}} and returns the result. Not recommended for very large graphs.
+Logical; Determines how the result of clustering is returned. If \code{FALSE}, returns a character vector corresponding to the path of \code{outfile}. If \code{TRUE}, parses \code{outfile} using \code{\link{read.table}} and returns the result (not recommended for very large graphs).
 }
 
 \item{consensus_cluster}{
-Should consensus clustering be used? If \code{TRUE}, runs the clustering algorithm multiple times and forms a consensus clustering based on the agreement of each run. Can be set to a vector of doubles to control the number of iterations. See "Consensus Clustering" below for more information.
+Logical or Numeric; Determines if consensus clustering should be used. If \code{TRUE}, runs the clustering algorithm multiple times and forms a consensus clustering based on the agreement of each run. Can be set to a numeric vector to control the number of iterations. See "Consensus Clustering" below for more information.
 }
 
 \item{use_fast_sort}{
-Should files be sorted using two files or in-place? If \code{TRUE}, ExoLabel will perform its file sorting functions using a second temporary file. This is faster than the in-place sort, but consumes twice the amount of disk space. The relative disk consumption is about the same size as the input graph for \code{use_fast_sort=FALSE}, and about double the size of the input graph for \code{use_fast_sort=TRUE} (see "Memory Consumption" and the last paragraph of "Warning" below). Set to \code{TRUE} if you're not worried about disk utilization.
+Logical; Determines how files should be sorted. If \code{FALSE}, ExoLabel will perform file sorting functions in-place. If \code{TRUE}, ExoLabel will perform its file sorting functions using a second temporary file. This is much faster than the in-place sort, but consumes twice the amount of disk space. The relative disk consumption is about the same size as the input graph for \code{use_fast_sort=FALSE}, and about double the size of the input graph for \code{use_fast_sort=TRUE} (see "Memory Consumption" and the last paragraph of "Warning" below). Set to \code{TRUE} if you're not worried about disk utilization.
 }
 
 \item{verbose}{
-Should status messages (output, progress, etc.) be displayed while running? Output messages are reduced if running in non-interactive mode.
+Logical; Determines if status messages (output, progress, etc.) should be displayed while running. Output messages are reduced if running in non-interactive mode.
 }
 
 \item{sep}{
-Character that separates entries on a line in each file in \code{edgelistfiles}. Defaults to tab, as would be expected in a \code{.tsv} formatted file. Set to \code{','} for a \code{.csv} file.
+Character; expected character that separates entries on a line in each file in \code{edgelistfiles}. Defaults to tab, as would be expected in a \code{.tsv} formatted file. Set to \code{','} for a \code{.csv} file.
 }
 \item{tempfiledir}{
-Character vector corresponding to the location where temporary files used during execution should be stored. Defaults to R's \code{\link{tempdir}}.
+Character; Vector corresponding to the location where temporary files used during execution should be stored.
 }
 }
 \details{
-Very large graphs require too much RAM for processing on some machines. In a graph containing billions of nodes and edges, loading the entire structure into RAM is rarely feasible. This implementation uses disk space for storing representations of each graph. While this is slower than computing on RAM, it allows this algorithm to scale to graphs of enormous size while only using a comparatively small amount of memory. See "Memory Consumption" for details on the total disk/memory consumption of ExoLabel.
+ExoLabel identifies communities (clusters) in graph/network structures using a variant of Fast Label Propagation, as proposed by Traag and Subelj (2023).
 
-This function expects a set of edgelist files, provided as a vector of filepaths. Each entry in the file is expected to be in the following:
+However, very large graphs require too much RAM for processing on some machines. In a graph containing billions of nodes and edges, loading the entire structure into RAM is rarely feasible. ExoLabel uses disk space for storing representations of graphs. While this is slower than computing on RAM, it allows ExoLabel to scale to graphs of enormous size while only using a comparatively small amount of memory. See "Memory Consumption" for details on the total disk/memory consumption of ExoLabel.
+
+ExoLabel expects a set of edgelist files, provided as a vector of filepaths. Each entry in the file is expected to be in the following:
 
 \code{VERTEX1<sep>VERTEX2<sep>WEIGHT<linesep>}
 
-This line defines a single edge between vertices \code{VERTEX1} and \code{VERTEX2} with weight \code{WEIGHT}. \code{VERTEX1} and \code{VERTEX2} are strings corresponding to vertex names, \code{WEIGHT} is a numeric value that can be interpreted as a \code{double}. The separators \code{<sep>} and \code{<linesep>} correspond to the arguments \code{sep} and \code{linesep}, respectively. The default arguments work for standard \code{.tsv} formatting, i.e., a file of three columns of tab-separated values.
+This line defines a single edge between vertices \code{VERTEX1} and \code{VERTEX2} with weight \code{WEIGHT}. \code{VERTEX1} and \code{VERTEX2} are strings corresponding to vertex names, \code{WEIGHT} is a numeric value that can be interpreted as a \code{double}. The separator \code{<sep>} corresponds to the argument \code{sep} (defaulting to tab for \code{.tsv} format), and \code{linesep} is the newline value \code{'\n'}.
 
 If \code{ignore_weight=TRUE}, the file can be formatted as:
 
 \code{VERTEX1<sep>VERTEX2<linesep>}
 
-Note that the \code{v1 v2 w} format is still accepted for \code{ignore_weight=FALSE}, but the specified weights will be ignored.
+Note that the \code{v1 v2 w} format is still accepted for \code{ignore_weight=FALSE}, but the weights will be ignored.
 }
 
 \section{Algorithm Convergence}{
 One of the main issues of Label Propagation algorithms is that they can fail to converge. Consider an unweighted directed graph with four nodes connected in a loop. That is, \code{A->B, B->C, C->D, D->A}. If \code{A,C} are in cluster 1 and \code{B,D} are in cluster 2, this algorithm could keep processing all the nodes in a loop and never converge. To solve this issue, we introduce an additional measure for convergence controlled by \code{iterations}. If \code{iterations=x}, then we only allow the algorithm to process each node \code{x} times. Once a given node has been seen \code{x} times, it is no longer updated. This can be manually specified, but defaults to the square root of the largest node indegree.
 
-Additionally, ExoLabel incorporates label hop attenuation to reduce the chance of a single massive cluster dominating  results. In short, as a particular label propagates to other nodes, its subsequent contribution diminishes. The farther a particular label is from its original source, the less its contribution. The degree to which its contribution diminishes scales dynamically based on the proportion of nodes that update on each cycle. Each node's attenuated weight is calculated as \eqn{w' = (1-p^ad)w}, where \eqn{w} the node weight, \eqn{p} the proportion of nodes that changed label in the previous iteration, \eqn{a} the attenuation power, and \eqn{d} the distance from the initial label. Larger values of \code{attenuation_power} create larger clusters, whereas smaller values create smaller clusters. The default value of 1 recovers the original implementation provided in Leung et al. (2009), linked in the References section. Passing a value of 0 disables attenuation entirely rather than returning all singleton clusters.
+Additionally, ExoLabel incorporates label hop attenuation to reduce the chance of a single massive cluster dominating  results. In short, as a particular label propagates to other nodes, its subsequent contribution diminishes. The farther a particular label is from its original source, the less its contribution. The degree to which its contribution diminishes scales dynamically based on the proportion of nodes that update on each cycle. Each node's attenuated weight is calculated as \eqn{w' = (1-p^ad)w}, where \eqn{w} the node weight, \eqn{p} the proportion of nodes that changed label in the previous iteration, \eqn{a} the attenuation power, and \eqn{d} the distance from the initial label. Larger values of \code{attenuation} create larger clusters, whereas smaller values create smaller clusters. The default value of \code{TRUE} (equivalent to 1.0) recovers the original implementation provided in Leung et al. (2009) linked in the References section. Passing a value of 0 (or \code{FALSE}) disables attenuation entirely rather than returning all singleton clusters.
 }
 
 \section{Multiple Clusterings}{
 A large portion of the processing time is reading in the graph object. This leads to a lot of duplicated effort when trying to cluster the same network with multiple parameters.
 
-Multiple clusterings on the same network are supported by sending vectors of input to \code{outfile} and \code{add_self_loops} or \code{attenuation_power}. If the length of \code{outfile} is greater than 1, \code{add_self_loops} and \code{attenuation_power} can each be set to either a single value or a vector of the same length as \code{outfile}. For a single value, the same parameter value will be used across all clusterings. For multiple values, the corresponding value will be used in each clustering. See "Examples" for example usage.
+Multiple clusterings on the same network are supported by passing vectors of input to \code{outfile} and \code{add_self_loops} or \code{attenuation}. If the length of \code{outfile} is greater than 1, \code{add_self_loops} and \code{attenuation} can each be set to either a single value or a vector of the same length as \code{outfile}. For a single value, the same parameter value will be used across all clusterings. For multiple values, the corresponding value will be used in each clustering. See "Examples" for example usage.
 
-Note that the order to process each node is randomly initialized, so multiple runs on the same parameters may differ due to this initialization step.
+Note that the order to process each node is randomly initialized, so multiple runs on the same parameters may produce different results if a random seed is not set.
 }
 
 \section{Consensus Clustering}{
@@ -112,7 +114,7 @@ Consensus clustering can be enabled by setting \code{consensus_cluster=TRUE}. Co
 \value{
 Returns a list object with the parameters and result of the clustering. If using multiple clusterings, the return value is a list of lists, with each entry corresponding to the single-clustering case. This list has two entries, \code{parameters} and \code{results}.
 
-\code{parameters} is a named vector with the values of \code{add_self_loops} and \code{attenuation_power} used for the clustering. If more parameters are added in the future, they'll be included in this vector.
+\code{parameters} is a named vector with the values of \code{add_self_loops} and \code{attenuation} used for the clustering. If more parameters are added in the future, they'll be included in this vector.
 
 \code{results} differs depending on the value of \code{return_table}.
 
@@ -130,9 +132,9 @@ Leung, X.Y.I., et al., \emph{Towards real-time community detection in large netw
 Aidan Lakshman <AHL27@pitt.edu>
 }
 \section{Warning}{
-While this algorithm can scale to very large graphs, it does have some internal limitations. First, nodes must be comprised of no more than 254 characters. If this limitation is restrictive, please feel free to contact me. Alternatively, you can increase the size yourself by changing the definition of \code{MAX_NODE_NAME_SIZE} in \code{src/OnDiskLP.c}. This limitation is provided to decrease memory overhead and improve runtime, but arbitrary values are possible.
+While this algorithm can scale to very large graphs, it does have some internal limitations. First, nodes must be comprised of no more than 254 characters. You can increase the size yourself by changing the definition of \code{MAX_NODE_NAME_SIZE} in \code{src/OnDiskLP.c}. This limitation is provided to decrease memory overhead and improve runtime, but arbitrary values are possible.
 
-Second, nodes are indexed using 54-bit unsigned integers. This means that the maximum possible number of nodes available is 2^54-1, which is about 1.8 quadrillion. As with character limitations, feel free to contact me if this is too restrictive. Alternatively, you can decrease the size of \code{BITS_FOR_WEIGHT} in \code{src/OnDiskLP.c}, but note that this value determines how many bits to use to represent weights internally, so lower values will lead to more error.
+Second, nodes are indexed using 54-bit unsigned integers. This means that the maximum possible number of nodes available is 2^54-1, which is about 1.8 quadrillion. You can decrease the size of \code{BITS_FOR_WEIGHT} in \code{src/OnDiskLP.c}, but note that this value determines how many bits to use to represent weights internally, so lower values will lead to less exact weights.
 
 Third, this algorithm uses disk space to store large objects. As such, please ensure you have sufficient disk space for the graph you intend to process. While there are safeguards in the code itself, unhandleable errors can occur when the OS runs out of space. Use \code{\link{EstimateExoLabel}} to estimate the disk consumption of your graph, and see "Memory Consumption" for more details on how the total disk/memory consumption is calculated. Note that using \code{use_fast_sort=TRUE} will double the maximal disk consumption of the algorithm.
 }

--- a/man/FitchParsimony.Rd
+++ b/man/FitchParsimony.Rd
@@ -9,7 +9,7 @@ Ancestral states for binary traits can be inferred from presence/absence pattern
 }
 \usage{
 FitchParsimony(dend, num_traits, traits_list,
-                  initial_state=rep(0L,num_traits), 
+                  initial_state=rep(0L,num_traits),
                   fill_ambiguous=TRUE)
 }
 %- maybe also 'usage' for other objects documented here.
@@ -18,20 +18,20 @@ FitchParsimony(dend, num_traits, traits_list,
   An object of class \code{'dendrogram'}
 }
   \item{num_traits}{
-  The number of traits to inferred, as an integer.
+  Integer; The number of traits to inferred.
 }
   \item{traits_list}{
-  A list of character vectors, where the \code{i}'th entry corresponds to the leaf labels that have the trait \code{i}. 
+  A list of character vectors, where the \code{i}'th entry corresponds to the leaf labels that have the trait \code{i}.
 }
   \item{initial_state}{
-  The state assumed for the root node. Set to \code{NULL} to disable autofilling the root state.
+  Integer; The state assumed for the root node. Set to \code{NULL} to disable autofilling the root state.
   }
   \item{fill_ambiguous}{
-  If \code{TRUE}, states that remain ambiguous after completion of the algorithm are filled in randomly.
+  Logical; Determines if states that remain ambiguous after completion of the algorithm should be filled in randomly.
   }
 }
 \details{
-Fitch Parismony allows for fast inference of ancestral states of binary traits. The algorithm proceeds in three steps. 
+Fitch Parismony allows for fast inference of ancestral states of binary traits. The algorithm proceeds in three steps.
 
 First, traits are inferred upwards based on child nodes. If the child nodes have the same state (\code{1/1} or \code{0/0}), then the parent node is also set to that state. If the states are different, the parent node is set to \code{2}, denoting an ambiguous entry. If one child is ambiguous and the other is not, the parent is set to the non-ambiguous entry.
 
@@ -39,14 +39,12 @@ Second, traits are inferred downward to attempt to fill in ambiguous entries. If
 
 Third, traits that remain ambiguous are optionally filled in (only if \code{fill_ambiguous} is set to \code{TRUE}). This proceeds by randomly setting ambiguous traits to either \code{1} or \code{0}.
 
-The result is stored in the \code{FitchState} attribute within each node. 
+The result is stored in the \code{FitchState} attribute within each node.
 }
 \value{
 A dendrogram with attribute \code{FitchState} set for each node, where this attribute is a binary vector of length \code{num_traits}.
 }
-\note{
-It's FitchParsimony because this implementation is entirely in R, as opposed to internal \code{SynExtend} methods that utilize a slightly faster C-based implementation that is not user-exposed.
-}
+
 \references{
 Fitch, Walter M. \emph{Toward defining the course of evolution: minimum change for a specific tree topology.} Systematic Biology, 1971. \bold{20}(4): p. 406-416.
 }
@@ -75,7 +73,7 @@ fpd <- dendrapply(fpd, \(x){
   ai <- 1L
   s <- attr(x, 'FitchState')
   l <- list()
-  
+
   if(is.leaf(x)){
     # coloring tips based presence/absence
     l$col <- ifelse(s[ai]==1L, 'green', 'red')
@@ -93,7 +91,7 @@ fpd <- dendrapply(fpd, \(x){
       attr(x[[i]], 'edgePar') <- l
     }
   }
-  
+
   x
 }, how='post.order')
 plot(fpd, leaflab='none')

--- a/man/MakeBlastDb.Rd
+++ b/man/MakeBlastDb.Rd
@@ -5,46 +5,46 @@ Create a BLAST Database from R
 }
 \description{
 Wrapper to create \href{https://blast.ncbi.nlm.nih.gov/Blast.cgi}{BLAST} databases for subsequent queries using the commandline BLAST tool directly from R.
-Can operate on an \code{\link[Biostrings]{XStringSet}} or a \code{FASTA} file. 
+Can operate on an \code{\link[Biostrings]{XStringSet}} or a \code{FASTA} file.
 
-This function requires the BLAST+ commandline tools, which can be downloaded 
+This function requires the BLAST+ commandline tools, which can be downloaded
 \href{https://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastDocs&DOC_TYPE=Download}{here}.
 }
 \usage{
-MakeBlastDb(seqs, dbtype=c('prot', 'nucl'), 
+MakeBlastDb(seqs, dbtype=c('prot', 'nucl'),
           dbname=NULL, dbpath=NULL,
-          extraArgs='', createDirectory=FALSE, 
+          extraArgs='', createDirectory=FALSE,
           verbose=TRUE)
 }
 \arguments{
   \item{seqs}{
-    Sequence(s) to create a BLAST database from. This can be either an 
+    Sequence(s) to create a BLAST database from. This can be either an
     \code{\link[Biostrings]{XStringSet}} or a path to a FASTA file.
   }
   \item{dbtype}{
-    Either \code{'prot'} for amino acid input, or \code{'nucl'} for nucleotide input.
+    Character; Either \code{'prot'} for amino acid input, \code{'nucl'} for nucleotide input, or an unambiguous abbreviation.
   }
   \item{dbname}{
-    Name of the resulting database. If not provided, defaults to
+    Character; Name of the resulting database. If not provided, defaults to
     a random string prefixed by \code{blastdb}.
   }
   \item{dbpath}{
-    Path where database should be created. If not provided, 
+    Character; Path where database should be created. If not provided,
     defaults to \code{\link{TMPDIR}}.
   }
   \item{extraArgs}{
-    Additional arguments to be passed to the query
-    executed on the command line. This should be a single character string.
+    Character; Additional arguments to be passed to the query
+    executed on the command line. This should be a single string.
   }
   \item{createDirectory}{
-    Should a directory be created for the database if it doesn't exist? If \code{FALSE}, the function will throw an error instead of creating a directory.
+    Logical; Determines if a directory should be created for the database if it doesn't already exist. If \code{FALSE}, the function will throw an error instead of creating a directory.
   }
   \item{verbose}{
-    Should output be displayed?
+    Logical; Determines if status messages should be displayed while running.
   }
 }
 \details{
-This offers a quick way to create BLAST databases from R. This function essentially wraps the \code{makeblastdb} commandline function. All arguments supported by \code{makeblastdb} are supported in the \code{extraArgs} argument.
+\code{MakeBlastDb} is a barebones wrapper for \code{makeblastdb} from the BLAST+ commandline tools. It is set up for convenience purposes only and does not add any additional functionality. Requires a functioning installation of the BLAST+ commandline tools.
 }
 \value{
 Returns a length 2 named character vector specifying the name of the BLAST database and the path to it.

--- a/man/MoransI.Rd
+++ b/man/MoransI.Rd
@@ -8,31 +8,33 @@ Moran's \emph{I} Spatial Autocorrelation Index
 Calculates Moran's \emph{I} to measure spatial autocorrelation for a set of signals dispersed in space.
 }
 \usage{
-MoranI(values, weights, alternative='two.sided')
+MoranI(values,
+       weights,
+       alternative=c('two.sided', 'less', 'greater'))
 }
 %- maybe also 'usage' for other objects documented here.
 \arguments{
   \item{values}{
-  Numeric vector containing signals for each point in space.
+  Numeric; Vector containing signals for each point in space.
 }
 \item{weights}{
-  Distances between each point in space. This should be a numeric object of class \code{\link{dist}} with \code{Size} attribute equivalent to the length of \code{values}. 
+  Numeric object of class \code{\link{dist}} with \code{Size} attribute equivalent to the length of \code{values}, representing distances between each point in space.
 }
 
 \item{alternative}{
-  For hypothesis testing against the null of no spatial correlation, how should a p-value be calculated? Should be one of \code{c("two.sided", "less", "greater")}, or an unambiguous abbreviation.
+  Character; determines how p-value should be calculated for hypothesis testing against the null of no spatial correlation. Should be one of \code{c("two.sided", "less", "greater")}, or an unambiguous abbreviation.
 }
 }
 \details{
   Moran's \emph{I} is a measure of how much the spatial arrangement of a set of datapoints correlates with the value of each datapoint. The index takes a value in the range \eqn{[-1,1]}, with values close to 1 indicating high correlation between location and value (points have increasingly similar values as they increase in proximity), values close to -1 indicating anticorrelation(points have increasingly different values as they increase in proximity), and values close to 0 indicating no correlation.
-  
+
   The value itself is calculated as:
 
 \deqn{I = \frac{N}{W}\frac{\sum_i^N \sum_j^N w_{ij}(x_i - \bar x)(x_j - \bar x)}{\sum_i^N (x_i - \bar x)^2}}
 
 Here, \eqn{N} is the number of points, \eqn{w_{ij}} is the distance between points \eqn{i} and \eqn{j}, \eqn{W = \sum_{i,j} w_{ij}} (the sum of all the weights), \eqn{x_i} is the value of point \eqn{i}, and \eqn{\bar x} is the sample mean of the values.
 
-Moran's \emph{I} has a closed form calculation for variance and expected value, which are calcalated within this function. The full form of the variance is fairly complex, but all the equations are available for reference \href{https://en.wikipedia.org/wiki/Moran\%27s_I#Expected_value}{here}.
+Moran's \emph{I} has a closed form calculation for variance and expected value, which are calculated within this function. The full form of the variance is fairly complex, but all the equations are available for reference \href{https://en.wikipedia.org/wiki/Moran\%27s_I#Expected_value}{here}.
 
 A p-value is estimated using the expected value and variance using a null hypothesis of no spatial autocorrelation, and the alternative hypothesis specified in the \code{alternative} argument. Note that if fewer than four datapoints are supplied, the variance of Moran's I is infinite. The function will return a standard deviation of \code{Inf} and a p-value of 1 in this case.
 }
@@ -66,11 +68,11 @@ Aidan Lakshman \email{ahl27@pitt.edu}
 # Make a distance matrix for a set of 50 points
 # These are just random numbers in the range [0.1,2]
 NUM_POINTS <- 50
-distmat <- as.dist(matrix(runif(NUM_POINTS**2, 0.1, 2), 
+distmat <- as.dist(matrix(runif(NUM_POINTS**2, 0.1, 2),
                           ncol=NUM_POINTS))
 
 # Generate some random values for each of the points
-vals <- runif(NUM_POINTS, 0, 3) 
+vals <- runif(NUM_POINTS, 0, 3)
 
 # Calculate Moran's I
 MoranI(vals, distmat, alternative='two.sided')

--- a/man/PhyloDistance-JRF.Rd
+++ b/man/PhyloDistance-JRF.Rd
@@ -3,13 +3,13 @@
 \alias{JRFDist}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{
-Jaccard-Robinson-Foulds Distance
+Jaccard-Robinson-Foulds Distance and Nye Similarity
 }
 \description{
-Calculate JRF distance between two unrooted phylogenies.
+Calculate JRF distance between two unrooted phylogenies. Nye Similarity is a special case of JRF distance, obtained when the JRF exponent \code{k} is set to 1.
 }
 \details{
-This function is called as part of \code{\link{PhyloDistance}} and calculates the Jaccard-Robinson-Foulds distance between two unrooted phylogenies. Each dendrogram is first pruned to only internal branches implying a partition in the shared leaf set; trivial partitions (where one leaf set contains 1 or 0 leaves) are ignored. 
+This function is called as part of \code{\link{PhyloDistance}} and calculates the Jaccard-Robinson-Foulds distance between two unrooted phylogenies. Each dendrogram is first pruned to only internal branches implying a partition in the shared leaf set; trivial partitions (where one leaf set contains 1 or 0 leaves) are ignored.
 
 The total score is calculated by pairing branches and scoring their similarity. For a set of two branches \eqn{A, B} that partition the leaves into \eqn{(A_1, A_2)} and \eqn{(B_1, B_2)} (resp.), the distance between the branches is calculated as:
 
@@ -17,14 +17,14 @@ The total score is calculated by pairing branches and scoring their similarity. 
 
 where \eqn{X \in (A_1, A_2),\; Y \in (B_1, B_2)} are chosen to maximize the score of the pairing, and \eqn{k} the value of \code{ExpVal}. The sum of these scores for all branches produces the overall distance between the two trees, which is then normalized by the number of branches in each tree.
 
-There are a few special cases to this distance. If \code{ExpVal=1}, the distance is equivalent to the metric introduced in Nye et al. (2006). As \code{ExpVal} approaches infinity, the value becomes close to the (non-Generalized) Robinson Foulds Distance.
+There are a few special cases to this distance. If \code{JRFExp=1}, the distance is equivalent to the metric introduced in Nye et al. (2006). As \code{JRFExp} approaches infinity, the value becomes close to the (non-Generalized) Robinson Foulds Distance.
 }
 \value{
 Returns a normalized distance, with 0 indicating identical trees and 1 indicating maximal difference.
 
 If \code{RawScore=TRUE}, returns a named length 3 vector with the first entry the summed distance score over the branch pairings, and the subsequent entries the number of partitions for each tree.
 
-If the trees have no leaves in common, the function will return \code{1} if 
+If the trees have no leaves in common, the function will return \code{1} if
 \code{RawScore=FALSE}, and \code{c(0, NA, NA)} if \code{TRUE}.
 }
 \references{
@@ -37,9 +37,9 @@ Aidan Lakshman \email{ahl27@pitt.edu}
 }
 \note{
 Note that this function requires the input dendrograms to be labeled alike (ex.
-leaf labeled \code{abc} in \code{dend1} represents the same species as 
-leaf labeled \code{abc} in \code{dend2}). 
-Labels can easily be modified using \code{\link{dendrapply}}. 
+leaf labeled \code{abc} in \code{dend1} represents the same species as
+leaf labeled \code{abc} in \code{dend2}).
+Labels can easily be modified using \code{\link{dendrapply}}.
 }
 
 \examples{

--- a/man/PhyloDistance.Rd
+++ b/man/PhyloDistance.Rd
@@ -23,10 +23,10 @@ PhyloDistance(dend1, dend2,
   tree.
 }
 \item{Method}{
-  Method to use for calculating tree distances. The following values are supported: \code{"CI", "RF", "KF", "JRF"}. See Details for more information.
+  Character; Method to use for calculating tree distances. The following values are supported: \code{"CI", "RF", "KF", "JRF"}. See Details for more information.
 }
 \item{RawScore}{
-  If \code{FALSE}, returns distance between the two trees. If \code{TRUE}, returns the component values used to calculate the distance. This may be preferred for methods like \code{GRF}. See the pages specific to each algorithm for more information on what values are reported.
+  Logical; Determines if the function should return the distance between two trees (\code{FALSE}) or the component values used to calculate the distance (\code{TRUE}). See the pages specific to each algorithm for more information on what values are reported.
 }
 \item{JRFExp}{
 \code{k}-value used in calculation of JRF Distance. Unused if \code{Method} is not \code{"JRF"}.
@@ -38,7 +38,7 @@ This function implements a variety of tree distances, specified by the value of 
 \itemize{
   \item{\code{"RF"}: \link[=RFDist]{Robinson-Foulds Distance}}
   \item{\code{"CI"}: \link[=CIDist]{Clustering Information Distance}}
-  \item{\code{"JRF"}: \link[=JRFDist]{Jaccard-Robinson-Foulds Distance}, equivalent to the Nye Distance Metric when \code{JRFVal=1}}
+  \item{\code{"JRF"}: \link[=JRFDist]{Jaccard-Robinson-Foulds Distance}, equivalent to the Nye Distance Metric when \code{JRFExp=1}}
   \item{\code{"KF"}: \link[=KFDist]{Kuhner-Felsenstein Distance}}
 }
 

--- a/man/RandForest.Rd
+++ b/man/RandForest.Rd
@@ -65,7 +65,7 @@ RandForest.fit(x, y=NULL,
   new data to predict on, typically provided as a \code{data.frame} object.
   }
   \item{verbose}{
-  logical: should progress be displayed?
+  Logical; Determines if status messages should be displayed while running.
   }
   \item{ntree}{
   number of decision trees to grow.

--- a/man/SuperTree.Rd
+++ b/man/SuperTree.Rd
@@ -5,8 +5,8 @@
 Create a Species Tree from Gene Trees
 }
 \description{
-Given a set of unrooted gene trees, creates a species tree. This function
-works for rooted gene trees, but may not accurately root the resulting tree.
+Given a set of unrooted gene trees, creates a species tree. While this function
+ also works for rooted gene trees, the resulting root may not be accurately placed.
 }
 \usage{
 SuperTree(myDendList, NAMEFUN=NULL, Verbose=TRUE, Processors=1)
@@ -17,7 +17,7 @@ SuperTree(myDendList, NAMEFUN=NULL, Verbose=TRUE, Processors=1)
   List of \code{dendrogram} objects, where each entry is an unrooted gene tree.
 }
 \item{NAMEFUN}{
-  Optional input specifying a function to apply to each leaf to convert gene tree leaf
+  Optional function to apply to each leaf to convert gene tree leaf
   labels into species names. This function should take as input a character vector
   and return a character vector of the same size. By default equals \code{NULL},
   indicating that gene tree leaves are already labeled with species identifiers.
@@ -25,11 +25,11 @@ SuperTree(myDendList, NAMEFUN=NULL, Verbose=TRUE, Processors=1)
 }
 
 \item{Verbose}{
-Should output be displayed?
+Logical; Determines if status messages and progress bars should be displayed while running.
 }
 
 \item{Processors}{
-Number of processors to use for calculating the final species tree.
+Integer; Number of processors to use for calculating the final species tree.
 }
 }
 \details{

--- a/man/dendrapply.Rd
+++ b/man/dendrapply.Rd
@@ -7,10 +7,10 @@ Apply a Function to All Nodes of a Dendrogram
 \description{
 Apply function FUN to each node of a dendrogram recursively. When y <- dendrapply(x, fn), then y is a dendrogram of the same graph structure as x and for each node, y.node[j] <- FUN( x.node[j], ...) (where y.node[j] is an (invalid!) notation for the j-th node of y). Also provides flexibility in the order in which nodes are evaluated.
 
-NOTE: This man page is for the \code{dendrapply} function defined in the \bold{SynExtend} package. See \code{?stats::dendrapply} for the default method (defined in the \bold{stats} package). 
+NOTE: This man page is for the \code{dendrapply} function defined in the \bold{SynExtend} package. See \code{?stats::dendrapply} for the default method (defined in the \bold{stats} package).
 }
 \usage{
-dendrapply(X, FUN, ..., 
+dendrapply(X, FUN, ...,
             how = c("pre.order", "post.order"))
 }
 %- maybe also 'usage' for other objects documented here.
@@ -25,13 +25,13 @@ An R function to be applied to each dendrogram node, typically working on its \c
 potential further arguments passed to \code{FUN}.
 }
   \item{how}{
-one of \code{c("pre.order", "post.order")}, or an unambiguous abbreviation. Determines if nodes should be evaluated according to an preorder (default) or postorder traversal. See details for more information.
+Character; one of \code{c("pre.order", "post.order")}, or an unambiguous abbreviation. Determines if nodes should be evaluated according to a preorder (default) or postorder traversal. See details for more information.
 }
 }
 \details{
-\code{"pre.order"} preserves the functionality of the previous \code{dendrapply}. For each node \code{n}, \code{FUN} is applied first to \code{n}, then to \code{n[[1]]} (and any children it may have), then \code{n[[2]]} and its children, etc. Notably, each node is evaluted \emph{prior to any} of its children.
+\code{"pre.order"} preserves the functionality of the previous \code{dendrapply}. For each node \code{n}, \code{FUN} is applied first to \code{n}, then to \code{n[[1]]} (and any children it may have), then \code{n[[2]]} and its children, etc. Notably, each node is evaluted \emph{prior to any} of its children (i.e., "top-down").
 
-\code{"post.order"} allows for calculations that depend on the children of a given node. For each node \code{n}, \code{FUN} is applied first to \emph{all} children of \code{n}, then is applied to \code{n} itself. Notably, each node is evaluated \emph{after all} of its children.
+\code{"post.order"} allows for calculations that depend on the children of a given node. For each node \code{n}, \code{FUN} is applied first to \emph{all} children of \code{n}, then is applied to \code{n} itself. Notably, each node is evaluated \emph{after all} of its children (i.e., "bottom-up").
 }
 \value{
 Usually a dendrogram of the same (graph) structure as \code{X}. For that, the function must be conceptually of the form \code{FUN <- function(X) \{ attributes(X) <- .....; X \}}, i.e., returning the node with some attributes added or changed.
@@ -50,7 +50,7 @@ The prior implementation of \code{dendrapply} was recursive and inefficient for 
 }
 
 \seealso{
-\code{\link{as.dendrogram}}, \code{\link[base]{lapply}} for applying a function to each component of a list. 
+\code{\link{as.dendrogram}}, \code{\link[base]{lapply}} for applying a function to each component of a list.
 
 \code{\link[base]{rapply}} is particularly useful for applying a function to the leaves of a dendrogram, and almost always be used when the function does not need to be applied to interior nodes due to significantly better performance.
 }
@@ -100,7 +100,7 @@ f <- function(x){
 preorder_try <- dendrapply(dend, f)
 dendrapply(preorder_try, \(x){ print(attr(x, 'newattr')); x })
 
-## trying with postorder, note that children nodes will already 
+## trying with postorder, note that children nodes will already
 ## have been populated, so no character(0) entries
 postorder_try <- dendrapply(dend, f, how='post.order')
 dendrapply(postorder_try, \(x){ print(attr(x, 'newattr')); x })

--- a/man/plot.EvoWeb.Rd
+++ b/man/plot.EvoWeb.Rd
@@ -4,12 +4,12 @@
 Plot predictions in a EvoWeb object
 }
 \description{
-EvoWeb objects are outputted from \code{\link{predict.EvoWeaver}}.
+EvoWeb objects can be returned from \code{\link{predict.EvoWeaver}}.
 
 This function plots the predictions in the object using a force-directed embedding
 of connections in the adjacency matrix.
 
-\emph{This function is still a work in progress.}
+\emph{This function is being targetting for additional functionality in later releases.}
 }
 \usage{
 \method{plot}{EvoWeb}(x, NumSims=10,
@@ -22,29 +22,29 @@ of connections in the adjacency matrix.
     A EvoWeb object. See \code{\link{EvoWeb}}
   }
   \item{NumSims}{
-    Number of iterations to run the model for.
+    Integer; Number of iterations to run the model for.
   }
   \item{Gravity}{
-    Strength of Gravity force. See 'Details'.
+    Numeric; Strength of Gravity force. See 'Details'.
   }
   \item{Coulomb}{
-    Strength of Coulomb force. See 'Details'.
+    Numeric; Strength of Coulomb force. See 'Details'.
   }
   \item{Connection}{
-    Strength of Connective force. See 'Details'.
+    Numeric; Strength of Connective force. See 'Details'.
   }
   \item{MoveRate}{
-    Controls how far each point moves in each iteration.
+    Numeric; Controls how far each point moves in each iteration.
   }
   \item{Cutoff}{
-    Cutoff value; if \code{abs(val) < Cutoff}, that Connection is shrunk to zero.
+    Numeric; Cutoff value; if \code{abs(val) < Cutoff}, that Connection is shrunk to zero.
   }
   \item{ColorPalette}{
-    Color palette for graphing. Valid inputs are any palette available in
+    Character; Color palette for graphing. Valid inputs are any palette available in
     \code{palette.pals()}. See \code{\link[grDevices]{palette}} for more info.
   }
   \item{Verbose}{
-    Logical indicating whether to print progress bars and messages. Defaults to \code{TRUE}.
+    Logical; Determines if status messages and progress bars should be displayed while running.
   }
   \item{...}{
     Additional parameters for consistency with generic.

--- a/man/predict.EvoWeaver.Rd
+++ b/man/predict.EvoWeaver.Rd
@@ -24,10 +24,10 @@ matrix with some extra S3 methods to make printing cleaner.
     A EvoWeaver object
   }
   \item{Method}{
-    Method(s) to use for prediction. This can be a character vector with multiple entries for predicting using multiple methods. See 'Details' for more information.
+    Character; Method(s) to use for prediction. This can be a character vector with multiple entries for predicting using multiple methods. See 'Details' for more information.
   }
   \item{Subset}{
-    Subset of data to predict on. This can either be a vector or a \code{2xN} matrix.
+    Either a vector or a \code{2xN} matrix representing the subset of data to predict on.
 
 
     If a vector, prediction proceeds for all possible pairs of elements specified in the vector
@@ -42,14 +42,14 @@ matrix with some extra S3 methods to make printing cleaner.
     \code{subset=1:3}.
   }
   \item{Processors}{
-    Number of cores to use for methods that support multithreaded execution.
+    Integer; Number of cores to use for methods that support multithreaded execution.
     Setting to \code{NULL} or a negative value will use the value of
     \code{detectCores()},
     or one core if the number of available cores cannot be determined. See Note
     for more information.
   }
   \item{MySpeciesTree}{
-    Phylogenetic tree of all genomes in the dataset. Required for \code{Method=c('RPContextTree', 'GLDistance', 'CorrGL', 'MoransI', 'Behdenna')}. \code{'Behdenna'} requires a rooted, bifurcating tree (other values of \code{Method} can handle arbitrary trees). Note that \code{EvoWeaver} can automatically infer a species tree if initialized with \code{dendrogram} objects.
+    Object of class \code{\link{dendrogram}} representing the phylogenetic relationship of all genomes in the dataset. Required for \code{Method=c('RPContextTree', 'GLDistance', 'CorrGL', 'MoransI', 'Behdenna')}. \code{'Behdenna'} requires a rooted, bifurcating tree (other values of \code{Method} can handle arbitrary trees). Note that \code{EvoWeaver} can automatically infer a species tree if initialized with \code{dendrogram} objects.
   }
   \item{PretrainedModel}{
     A pretrained model for use with ensemble predictions. The default
@@ -63,7 +63,7 @@ matrix with some extra S3 methods to make printing cleaner.
     Has no effect if \code{Method != 'Ensemble'}.
   }
   \item{NoPrediction}{
-    For \code{Method='Ensemble'}, should data be returned prior to making predictions?
+    Logical; determines if data should be returned prior to making prediction for \code{Method='Ensemble'}.
 
     If \code{TRUE}, this will instead return a \link[base]{data.frame} object
     with predictions from each algorithm for each pair. This dataframe is typically
@@ -73,17 +73,16 @@ matrix with some extra S3 methods to make printing cleaner.
     if provided or a built-in otherwise).
   }
   \item{ReturnDataFrame}{
-    Logical indicating whether to return a \code{data.frame} object or a list of \code{EvoWeb} objects.
-    Defaults to \code{TRUE}. Setting this parameter to \code{FALSE} is not recommended for typical users.
+    Logical; Determines if the function should return a \code{data.frame} object or a list of \code{EvoWeb} objects. Setting this parameter to \code{FALSE} is not recommended.
   }
   \item{Verbose}{
-    Logical indicating whether to print progress bars and messages. Defaults to \code{TRUE}.
+    Logical; Determines if status messages and progress bars should be displayed while running.
   }
   \item{CombinePVal}{
-    Logical indicating whether to combine scores and p-values or to return them as separate values. Defaults to \code{TRUE}.
+    Logical; Determines if scores and p-values should be combined or returned as separate values.
   }
   \item{useDNA}{
-    Logical indicating whether to interpret sequences as DNA or AA (only used for Sequence Level methods, see Details).
+    Logical; Determines whether to interpret sequences as DNA or AA (only used for Sequence Level methods, see Details).
   }
   \item{...}{
     Additional parameters for other predictors and consistency with generic.
@@ -111,12 +110,12 @@ following pages:
 
 \item \link[=EvoWeaver-GOPreds]{EvoWeaver Gene Organization Methods}
 
-\item \link[=EvoWeaver-SLPreds]{EvoWeaver Sequence-Level Methods}
+\item \link[=EvoWeaver-SLPreds]{EvoWeaver Sequence Level Methods}
 }
 
 The standard return type is a \code{data.frame} object with one column per predictor and an additional two columns specifying the genes in each pair. If \code{ReturnDataFrame=FALSE}, this returns a \code{EvoWeb} object. See \code{\link{EvoWeb}} for more information. Use of this parameter is discouraged.
 
-By default, EvoWeaver weights scores by their p-value to correct for spurious correlations. The returned scores are \code{raw_score*(1-p_value)}. If \code{CombinePVal=FALSE}, EvoWeaver will instead return the raw score and the p-value separately. The resulting data.frame will have one column for the raw score (denoted \code{METHOD.score}) and one column for the p-value (denoted \code{METHOD.pval}). **Note: p-values are recorded as (1-p)**. Not all methods support returning p-values separately from the score; in this case, only a \code{METHOD.score} column will be returned.
+By default, EvoWeaver weights scores by their p-value to correct for spurious correlations. The returned scores are \code{raw_score*(1-p_value)}. If \code{CombinePVal=FALSE}, EvoWeaver will instead return the raw score and the p-value separately. The resulting data.frame will have one column for the raw score (denoted \code{METHOD.score}) and one column for the p-value (denoted \code{METHOD.pval}). \bold{Note: p-values are recorded as (1-p)}. Not all methods support returning p-values separately from the score; in this case, only a \code{METHOD.score} column will be returned.
 
 Different methods require different types of input. The constructor
 \code{\link{EvoWeaver}} will notify the user which methods are
@@ -127,13 +126,7 @@ See \code{\link{EvoWeaver}} for more information on input data types.
 
 Complete listing of all supported methods (asterisk denotes a method used in \code{Ensemble}, if possible):
 \itemize{
-  \item \code{'ExtantJaccard'}: Jaccard Index of Presence/Absence (P/A) profiles at extant leaves
-  \item \code{'Hamming'}: Hamming similarity of P/A profiles
   \item * \code{'GLMI'}: MI of G/L profiles
-  \item \code{'PAPV'}: \code{1-p_value} of P/A profiles
-  \item \code{'ProfDCA'}: Direct Coupling Analysis of P/A profiles
-  \item \code{'Behdenna'}: Analysis of Gain/Loss events following Behdenna et al. (2016)
-  \item \code{'CorrGL'}: Correlation of ancestral Gain/Loss events
   \item * \code{'GLDistance'}: Score-based method based on distance between inferred ancestral Gain/Loss events
   \item * \code{'PAJaccard'}: Centered Jaccard distance of P/A profiles with conserved clades collapsed
   \item * \code{'PAOverlap'}: Conservation of ancestral states based on P/A profiles
@@ -144,10 +137,16 @@ Complete listing of all supported methods (asterisk denotes a method used in \co
   \item * \code{'OrientationMI'}: Mutual Information of Gene Relative Orientation
   \item * \code{'GeneVector'}: Correlation of distribution of sequence level residues following Zhao et al. (2022)
   \item * \code{'SequenceInfo'}: Mutual information of sites in multiple sequence alignment
+  \item \code{'ExtantJaccard'}: Jaccard Index of Presence/Absence (P/A) profiles at extant leaves
+  \item \code{'Hamming'}: Hamming similarity of P/A profiles
+  \item \code{'PAPV'}: \code{1-p_value} of P/A profiles
+  \item \code{'ProfDCA'}: Direct Coupling Analysis of P/A profiles
+  \item \code{'Behdenna'}: Analysis of Gain/Loss events following Behdenna et al. (2016)
+  \item \code{'CorrGL'}: Correlation of ancestral Gain/Loss events
 }
 }
 \value{
-Returns a \code{data.frame} object where each row corresponds to a single prediction for a pair of gene groups. The first two columns contain the gene group identifiers for each pair, and the remaining columns contain each prediction.
+If \code{ReturnDataFrame=TRUE}, returns a \code{data.frame} object where each row corresponds to a single prediction for a pair of gene groups. The first two columns contain the gene group identifiers for each pair, and the remaining columns contain each prediction.
 
 If \code{ReturnDataFrame=FALSE}, the return type is a list of \code{EvoWeb} objects. See \code{\link{EvoWeb}} for more info.
 }
@@ -156,15 +155,9 @@ Aidan Lakshman \email{ahl27@pitt.edu}
 }
 
 \note{
-EvoWeaver's publication used a random forest model from the \code{randomForest} package for prediction. The next release of EvoWeaver will include multiple new built-in ensemble methods, but in the interim users are recommended to rely on \code{randomForest} or \code{neuralnet}. Planned algorithms are random forests and feed-forward neural networks. Feel free to contact me regarding other models you would like to see added.
-
   If \code{NumCores} is set to \code{NULL}, EvoWeaver will use one less core than is detected, or one core if \code{detectCores()}
-  cannot detect the number of available cores. This is because of a recurring issue
-  on my machine where the R session takes all available cores and is then locked
-  out of forking processes, with the only solution to restart the entire R session.
-  This may be an issue specific to ARM Macs, but out of an abundance of caution
-  I've made the default setting to be slightly slower but guarantee completion
-  rather than risk bricking a machine.
+  cannot detect the number of available cores. This is because of a potential
+  issue where the R session can consume all available cores and then lose the ability to fork processes, with the only solution to restart the entire R session.
 
 If \code{ReturnDataFrame=FALSE} and \code{CombinePVal=FALSE}, the resulting \code{EvoWeb} objects will contain values of type \code{'complex'}. For each value, the real part denotes the raw score, and the imaginary part denotes \code{1-p}, with \code{p} the p-value.
 }
@@ -180,7 +173,7 @@ If \code{ReturnDataFrame=FALSE} and \code{CombinePVal=FALSE}, the resulting \cod
 
 \link[=EvoWeaver-GOPreds]{EvoWeaver Gene Organization Predictors}
 
-\link[=EvoWeaver-SLPreds]{EvoWeaver Sequence-Level Predictors}
+\link[=EvoWeaver-SLPreds]{EvoWeaver Sequence Level Predictors}
 }
 \examples{
 ##############

--- a/man/simMat.Rd
+++ b/man/simMat.Rd
@@ -15,7 +15,7 @@
 Similarity Matrices
 }
 \description{
-The \code{simMat} object is an internally utilized class that provides similar 
+The \code{simMat} object is an internally utilized class that provides similar
 functionality to the \code{\link{dist}} object, but with matrix-like accessors.
 
 Like \code{dist}, this object stores values as a vector, reducing memory by
@@ -47,23 +47,23 @@ be provided for this function if desired.
 }
 \item{nelem}{
 Integer; number of elements represented in the matrix. This corresponds to the
-number of rows and columns of the object, so setting \code{nelem=10} would 
+number of rows and columns of the object, so setting \code{nelem=10} would
 produce a \code{10x10} matrix.
 }
 \item{NAMES}{
-Character (Optional); names for each row/column. If provided, this should be 
+Character (Optional); names for each row/column. If provided, this should be
 a character vector of length equal to \code{nelem}.
 }
 \item{DIAG}{
-Logical; Is the diagonal included in the data? If \code{FALSE}, the constructor
+Logical; Determines if the diagonal is included in the data. If \code{FALSE}, the constructor
 generates 1s for the diagonal.
 }
-\item{x}{Various; for \code{print} and \code{Diag}, the \code{"simMat"} object to print. For \code{as.vector} or \code{as.matrix}, the vector or matrix (respectively). Note that \code{as.matrix} expects a symmetric matrix--providing a non-symmetric matrix will take only the upper triangle and produce a warning.}
+\item{x}{For \code{print} and \code{Diag}, the \code{"simMat"} object to print. For \code{as.vector} or \code{as.matrix}, the vector or matrix (respectively). Note that \code{as.matrix} expects a symmetric matrix--providing a non-symmetric matrix will take only the upper triangle and produce a warning.}
 \item{value}{Numeric; value(s) to replace diagonal with.}
 \item{...}{Additional parameters provided for consistency with generic.}
 }
 \details{
-The \code{simMat} object has a very similar format to \code{dist} objects, but 
+The \code{simMat} object has a very similar format to \code{dist} objects, but
 with a few notable changes:
 
 \itemize{
@@ -77,13 +77,13 @@ zeros as in \code{dist} objects.
 
 See the examples for details on using these features.
 
-The number of elements printed when calling \code{print} or \code{show} on a 
+The number of elements printed when calling \code{print} or \code{show} on a
 \code{simMat} object is determined by the \code{"SynExtend.simMat"} option.
 }
 \value{
 \code{simMat} and \code{as.simMat} return an object of class \code{"simMat"}. Internally,
 the object stores the upper triangle of the matrix similar to how \code{dist}
-stores objects. 
+stores objects.
 
 The object has the following attributes (besides \code{"class"} equal to \code{"simMat"}):
 

--- a/man/subset-dendrogram.Rd
+++ b/man/subset-dendrogram.Rd
@@ -18,10 +18,10 @@ NOTE: This man page is specifically for \code{subset.dendogram}, see \code{?base
   An object of class \code{'dendogram'}
 }
 \item{subset}{
-  A vector of labels to keep (see \code{invert}).
+  Character; A vector of labels to keep (see \code{invert}).
 }
 \item{invert}{
-  If set to \code{TRUE}, subset to only the leaves \emph{not} in \code{subset}.
+  Logical; If \code{TRUE}, subsets to the leaves \emph{not} in \code{subset}.
 }
 \item{...}{
 Additional arguments for consistency with generic.
@@ -29,7 +29,7 @@ Additional arguments for consistency with generic.
 }
 
 \value{
-An object of class \code{'dendrogram'} corresponding to the subsetted tree.
+An object of class \code{'dendrogram'} corresponding to the subset of the tree.
 }
 
 \author{

--- a/src/OnDiskLP.c
+++ b/src/OnDiskLP.c
@@ -1236,6 +1236,7 @@ static void reset_trie_clusters(l_uint num_v){
   for(l_uint i=0; i<num_v; i++){
     l = GLOBAL_all_leaves[i];
     l->count = l->index+1;
+    l->dist = 0;
   }
 
   return;
@@ -1412,7 +1413,7 @@ static void add_remaining_to_queue(l_uint new_clust, leaf **neighbors,
     if(tmp_cl == new_clust || weights[i] < CLUSTER_MIN_WEIGHT) continue;
     tmp_ind = neighbors[i]->index;
     found = 0;
-    for(int j=0; j<ctr; j++){
+    for(l_uint j=0; j<ctr; j++){
       if(neighbors[j]->index == tmp_ind){
         found = 1;
         break;


### PR DESCRIPTION
- updates documentation files according to internal feedback
- changes `attenuation_power` to `attenuation` in ExoLabel
- `attenuation` is now `TRUE/FALSE`, but supports numeric arguments
- Fixes a bug where vectorized input to ExoLabel would fail to reset attenuation distances between runs

Note: Version is not incremented with this PR since a bunch more documentation changes are in the pipeline for Nick. Assuming they can all get rolled into one version increment.