### PR TITLE
fix: bugfixes and QoL changes to ExoLabel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SynExtend
 Type: Package
 Title: Tools for Working With Synteny Objects
-Version: 1.19.8
+Version: 1.19.9
 Authors@R: c(
 	person("Nicholas", "Cooley", email = "npc19@pitt.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6029-304X")),
 	person("Aidan", "Lakshman", email = "ahl27@pitt.edu", role = c("aut", "ctb"), comment = c(ORCID = "0000-0002-9465-6785")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# SynExtend 1.19.9
+* Bugfixes to `ExoLabel`
+* `ExoLabel` now defaults to `use_fast_sort=TRUE`
+* Various QoL changes for `ExoLabel(..., return_table=TRUE)`
+* `ExoLabel` now correctly reports timing
+
 # SynExtend 1.19.8
 * `ExoLabel` has a new parameter to tune the performance of hop-length attenuation.
 * Documentation and formatting updates.

--- a/R/ExoLabel.R
+++ b/R/ExoLabel.R
@@ -1,4 +1,5 @@
-ExoLabel <- function(edgelistfiles, outfile=tempfile(),
+ExoLabel <- function(edgelistfiles,
+                          outfile=tempfile(tmpdir=tempfiledir),
                           mode=c("undirected", "directed"),
                           add_self_loops=FALSE,
                           attenuation=TRUE,
@@ -10,7 +11,17 @@ ExoLabel <- function(edgelistfiles, outfile=tempfile(),
                           verbose=interactive(),
                           sep='\t',
                           tempfiledir=tempdir()){
-  ## TODO: auto-select enough tempfiles if return_table=FALSE
+  if(return_table){
+    maxp <- max(length(add_self_loops),
+                length(attenuation),
+                length(iterations))
+    if(!missing(outfile)){
+      warning("'outfile' will be ignored since return_table=TRUE")
+    }
+    if(length(outfile) != maxp){
+      outfile <- replicate(maxp, tempfile(tmpdir=tempfiledir))
+    }
+  }
   if(!is.numeric(iterations)){
     stop("'iterations' must be an integer or numeric.")
   } else {

--- a/R/ExoLabel.R
+++ b/R/ExoLabel.R
@@ -15,13 +15,13 @@ ExoLabel <- function(edgelistfiles, outfile=tempfile(),
   } else {
     iterations <- as.integer(iterations)
   }
-  if(iterations > 2^15){
+  if(any(iterations > 2^15)){
     warning("'iterations' currently only supports signed 16-bit numbers, defaulting to max possible value of 32767.")
-    iterations <- 32767L
+    iterations[iterations > 2^15] <- 32767L
   }
-  if(is.na(iterations) || is.null(iterations) || is.infinite(iterations) || iterations < 0){
+  if(any(is.na(iterations) | is.null(iterations) | is.infinite(iterations) | iterations < 0)){
     warning("Invalid value of 'iterations', will determine automatically from node degree.")
-    iterations <- 0L
+    iterations[is.na(iterations) | is.null(iterations) | is.infinite(iterations) | iterations < 0] <- 0L
   }
   if(!is.numeric(add_self_loops) && !is.logical(add_self_loops)){
     stop("value of 'add_self_loops' should be numeric or logical")
@@ -63,10 +63,14 @@ ExoLabel <- function(edgelistfiles, outfile=tempfile(),
   if(length(attenuation) == 1){
     attenuation <- rep(attenuation, length(outfile))
   }
-  if(length(outfile) != length(add_self_loops) ||
-     length(attenuation) != length(add_self_loops)){
-      stop("If more than one outfile is provided, 'add_self_loops' and ",
-          "'attenuation' must be either the same length as 'outfile' ",
+  if(length(iterations) == 1){
+    iterations <- rep(iterations, length(outfile))
+  }
+  if(length(add_self_loops) != length(outfile) ||
+     length(attenuation) != length(outfile) ||
+     length(iterations) != length(outfile)){
+      stop("If more than one outfile is provided, 'add_self_loops', 'iterations'",
+          ", and 'attenuation' must be either the same length as 'outfile' ",
           "or length 1.")
   }
   if(!is.logical(verbose) || !is.numeric(verbose)){

--- a/R/ExoLabel.R
+++ b/R/ExoLabel.R
@@ -6,10 +6,11 @@ ExoLabel <- function(edgelistfiles, outfile=tempfile(),
                           iterations=0L,
                           return_table=FALSE,
                           consensus_cluster=FALSE,
-                          use_fast_sort=FALSE,
+                          use_fast_sort=TRUE,
                           verbose=interactive(),
                           sep='\t',
                           tempfiledir=tempdir()){
+  ## TODO: auto-select enough tempfiles if return_table=FALSE
   if(!is.numeric(iterations)){
     stop("'iterations' must be an integer or numeric.")
   } else {

--- a/man/ExoLabel.Rd
+++ b/man/ExoLabel.Rd
@@ -37,7 +37,7 @@ Character; Specifies whether edges should be interpreted as undirected (default)
 }
 
 \item{add_self_loops}{
-Logical or Numeric; Determines if self loops should be added to the network. If \code{TRUE}, adds self loops of weight 1.0 to all vertices. If set to numeric value \code{w}, adds self loops of weight \code{w} to all nodes. Can also be set to a vector when running multiple clusterings (see Details).
+Logical or Numeric; Determines if a self-loop cutoff should be added to the network. A self-loop cutoff of value \code{w} requires that at least one incoming edge has weight \code{w} in order to assign the node to that cluster (See "Self-Loops" for more information). If \code{TRUE}, adds self-loop cutoffs of weight 1.0 to all vertices. If set to numeric value \code{w}, adds self-loop cutoffs of weight \code{w} to all nodes. Can also be set to a vector when running multiple clusterings (see Details).
 }
 
 \item{attenuation}{
@@ -91,6 +91,14 @@ If \code{ignore_weight=TRUE}, the file can be formatted as:
 \code{VERTEX1<sep>VERTEX2<linesep>}
 
 Note that the \code{v1 v2 w} format is still accepted for \code{ignore_weight=FALSE}, but the weights will be ignored.
+}
+
+\section{Self-Loops}{
+  Label Propagation algorithms are susceptible to a large number of small weights outcompeting small numbers of strong edges. While self-loops can be added to mitigate this problem, they fail to scale to larger networks because noise scales quadratically, whereas self-loops scale linearly. The standard usage of self-loops adds a self-loop edge with fixed weight \eqn{w} to each node, essentially requiring any node's neighboring communities to have at least weight \eqn{w} to propagate. In a setting like orthology detection, spurious similarity scores will eventually outweigh both true similarities and the self-loop edges.
+
+  To combat this, we treat self-loop values as a "self-loop cutoff" rather than a fixed value. Self-loop cutoffs are a value \eqn{w'} such that all neighboring communities must have at least one edge of weight \eqn{w'} in order to propagate. With this usage, even if a node has many neighbors in the same community with spurious similarities, it must have at least one neighbor in that community with a strong similarity in order for the node to join that community. This approach scales better with the size of graphs compared to the traditional usage of self-loops.
+
+  As an example, consider a node \eqn{N} not yet assigned to a community with 10 neighbors. Neighbors 1-9 are in community 1 with weight 0.1, and neighbor 10 is in community 2 with weight 0.8. Community 1 thus has weight 0.9, and community 2 has weight 0.8. In the context of orthology detection, values below 0.2 are likely to be spurious. With a self-loop of 0.4, \eqn{N} would still be assigned to community 1, despite these being likely spurious. However, with a self-loop cutoff of 0.4, \eqn{N} would be assigned to community 2 because no edge in community 1 is at least 0.4.
 }
 
 \section{Algorithm Convergence}{

--- a/man/ExoLabel.Rd
+++ b/man/ExoLabel.Rd
@@ -17,7 +17,7 @@ ExoLabel(edgelistfiles,
               iterations=0L,
               return_table=FALSE,
               consensus_cluster=FALSE,
-              use_fast_sort=FALSE,
+              use_fast_sort=TRUE,
               verbose=interactive(),
               sep='\t',
               tempfiledir=tempdir())
@@ -61,7 +61,7 @@ Logical or Numeric; Determines if consensus clustering should be used. If \code{
 }
 
 \item{use_fast_sort}{
-Logical; Determines how files should be sorted. If \code{FALSE}, ExoLabel will perform file sorting functions in-place. If \code{TRUE}, ExoLabel will perform its file sorting functions using a second temporary file. This is much faster than the in-place sort, but consumes twice the amount of disk space. The relative disk consumption is about the same size as the input graph for \code{use_fast_sort=FALSE}, and about double the size of the input graph for \code{use_fast_sort=TRUE} (see "Memory Consumption" and the last paragraph of "Warning" below). Set to \code{TRUE} if you're not worried about disk utilization.
+Logical; Determines how files should be sorted. If \code{FALSE}, ExoLabel will perform file sorting functions in-place. If \code{TRUE}, ExoLabel will perform its file sorting functions using a second temporary file. This is much faster than the in-place sort, but consumes twice the amount of disk space. The relative disk consumption is about the same size as the input graph for \code{use_fast_sort=FALSE}, and about double the size of the input graph for \code{use_fast_sort=TRUE} (see "Memory Consumption" and the last paragraph of "Warning" below). Set to \code{FALSE} if you're worried about disk utilization.
 }
 
 \item{verbose}{

--- a/src/OnDiskLP.c
+++ b/src/OnDiskLP.c
@@ -286,7 +286,7 @@ static ArrayQueue* init_array_queue(l_uint size, int max_seen){
 /********************/
 
 static void report_time(time_t time1, time_t time2, const char* prefix){
-  double elapsed_time = difftime(time2, time1);//((double)(end - start)) / CLOCKS_PER_SEC;
+  double elapsed_time = difftime(time2, time1);
   int mins, hours, days, secs;
   secs = (int)fmod(elapsed_time, 60);
 

--- a/src/OnDiskLP.c
+++ b/src/OnDiskLP.c
@@ -1955,7 +1955,7 @@ SEXP R_LPOOM_cluster(SEXP FILENAME, SEXP NUM_EFILES, // files
 
   // change edge_start values to cumulative counts
   GLOBAL_all_leaves[num_v] = malloc(sizeof(leaf));
-  GLOBAL_all_leaves[num_v]->count = 0;
+  GLOBAL_all_leaves[num_v]->edge_start = 0;
   l_uint running_sum = 0;
   for(l_uint i=0; i<=num_v; i++){
     leaf* tmp_leaf = GLOBAL_all_leaves[i];

--- a/src/OnDiskLP.c
+++ b/src/OnDiskLP.c
@@ -198,7 +198,6 @@ static void **GLOBAL_mergebuffers = NULL;
 static LoserTree *GLOBAL_mergetree = NULL;
 static double GLOBAL_max_weight = 1.0;
 static l_uint GLOBAL_verts_changed = 0;
-static float GLOBAL_atten_user_power = 1.0;
 
 /***************************/
 /* Struct Helper Functions */
@@ -1489,7 +1488,7 @@ static void update_node_cluster(l_uint ind,
     // attenuate edges, using adaptive scaling
     // see https://doi.org/10.1103/PhysRevE.83.036103, eqns 4-5
     weights_arr[i] *= 1-(atten_param * neighbors[i]->dist);
-    if(weights_arr[i] < CLUSTER_MIN_WEIGHT) weights_arr[i] = 0;
+    if(fabs(weights_arr[i]) < CLUSTER_MIN_WEIGHT) weights_arr[i] = 0;
   }
   free(clusts);
 
@@ -1606,7 +1605,7 @@ static void cluster_file(const char* offsets_fname, const char* weights_fname,
       if(atten_pow == 0){
         atten_param = 0;
       } else if (atten_pow != 1){
-        atten_param = pow(atten_param, GLOBAL_atten_user_power);
+        atten_param = pow(atten_param, atten_pow);
       }
       iteration_length = GLOBAL_queue->length;
       GLOBAL_verts_changed = 0;

--- a/src/OnDiskLP.c
+++ b/src/OnDiskLP.c
@@ -1505,7 +1505,7 @@ static void update_node_cluster(l_uint ind,
 
 
   // figure out the cluster to update to
-  double max_weight, cur_weight=0, cur_error=0;
+  double max_weight=0, cur_weight=0, cur_error=0;
   l_uint max_clust=0, cur_clust=neighbors[num_edges]->count;
   dist_uint new_dist = -1, min_dist = -1; // type defined in PrefixTrie.h
   leaf* cur_neighbor;
@@ -1527,12 +1527,17 @@ static void update_node_cluster(l_uint ind,
       min_dist = min_dist > cur_neighbor->dist ? cur_neighbor->dist : min_dist;
     }
   }
-
-  if(max_weight < cur_weight || max_clust == 0){
-    // max_clust == 0 case is for when the node has no edges,
-    // which would skip the above loop and assign the node to 0 (invalid)
+  if(max_weight < cur_weight){
     max_weight = cur_weight;
     max_clust = cur_clust;
+    new_dist = min_dist;
+  }
+  if(max_clust == 0){
+    // max_clust == 0 case is for when the node has no edges,
+    // which would skip the above loop and assign the node to 0 (invalid)
+    // we could also never update it because all weights are negative
+    // (due to attenuation)
+    max_clust = neighbors[num_edges]->count;
   }
 
   // have to actually write the new cluster and add changed nodes

--- a/src/OnDiskLP.c
+++ b/src/OnDiskLP.c
@@ -732,7 +732,12 @@ static void kway_mergesort_file_inplace(const char* f1, l_uint nlines,
   }
   // cur_source will always be the file we just WROTE to here
 
-  if(verbose >= VERBOSE_BASIC) Rprintf("\n");
+  if(verbose == VERBOSE_ALL){
+    Rprintf("\tIteration %" lu_fprint " of %" lu_fprint " (%5.01f%% complete, used ",
+                            tmpniter, nmax_iterations, 100.0);
+    report_filesize(max_fsize);
+    Rprintf(")  \n");
+  }
   for(int i=0; i<num_bins; i++) free(buffers[i]);
   free(buffers);
   fclose_tracked(1);
@@ -916,7 +921,7 @@ static void kway_mergesort_file(const char* f1, const char* f2, l_uint nlines,
 
   if(verbose == VERBOSE_ALL){
     Rprintf("\tIteration %" lu_fprint " of %" lu_fprint " (%5.01f%% complete, used ",
-                      tmpniter, nmax_iterations, cur_progress);
+                      tmpniter, nmax_iterations, 100.0);
     report_filesize(max_fsize);
     Rprintf(")  \n");
   }
@@ -1874,14 +1879,11 @@ static l_uint write_output_clusters_trie(FILE *outfile, prefix *trie, l_uint *cl
           clust_mapping[tmpval] = CLUST_MAP_CTR++;
         }
         tmpval = clust_mapping[tmpval];
-        //fseek(clusterfile, tmpval*L_SIZE, SEEK_SET);
-        //safe_fread(&tmpval, L_SIZE, 1, clusterfile);
 
         // prepare data for output
         s[cur_pos] = 0;
         snprintf(write_buf, num_bytes, "%s%c%" lu_fprint "%c", s, seps[0], tmpval, seps[1]);
-        // DEBUG: Get indices for each vertex
-        // Rprintf("%s (%" lu_fprint ")\n", s, ((leaf *)(trie->child_nodes[0]))->index);
+
         safe_fwrite(write_buf, 1, strlen(write_buf), outfile);
         num_v--;
         if(num_v % PROGRESS_COUNTER_MOD == 0){

--- a/src/OnDiskLP.c
+++ b/src/OnDiskLP.c
@@ -919,9 +919,8 @@ static void kway_mergesort_file(const char* f1, const char* f2, l_uint nlines,
     Rprintf("\tIteration %" lu_fprint " of %" lu_fprint " (%5.01f%% complete, used ",
                       tmpniter, nmax_iterations, cur_progress);
     report_filesize(max_fsize);
-    Rprintf(")  \r");
-  } else {}
-  R_CheckUserInterrupt();
+    Rprintf(")  \n");
+  }
   for(int i=0; i<num_bins; i++) free(buffers[i]);
   free(buffers);
 

--- a/src/PrefixTrie.c
+++ b/src/PrefixTrie.c
@@ -4,6 +4,7 @@ leaf *alloc_leaf() {
 	leaf *node = safe_malloc(sizeof(leaf));
 	node->count = 0;
 	node->index = 0;
+	node->edge_start = 0;
 	node->dist = 0;
 	return node;
 }

--- a/src/PrefixTrie.h
+++ b/src/PrefixTrie.h
@@ -18,8 +18,9 @@
 #define MIN_VALUE_BMAP2 87
 
 typedef struct leaf {
-	trie_uint count; //(making this uint32_t can save a lot of space)
+	trie_uint count; // also tracks the cluster number
 	trie_uint index;
+	trie_uint edge_start; // start position of edges in the disk file
 	dist_uint dist; // distance to original label, used for attentuation
 } leaf;
 


### PR DESCRIPTION
Bugfixes:
- ExoLabel now correctly assigns cluster when all incoming edges are negative
- ExoLabel now generates sufficient temporary files when multiple runs are requested and `return_table=TRUE`
- ExoLabel now correctly reports timing (previously underreported by a lot due to how `clock` works)
- ExoLabel now correctly uses provided attenuation powers
- ExoLabel no longer squashes negative weights to zero

Changes:
- ExoLabel's `iteration` argument is now vectorized
- `use_fast_sort` now defaults to TRUE
- updates to documentation