### PR TITLE
fix: tech debt cleanup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SynExtend
 Type: Package
 Title: Tools for Comparative Genomics
-Version: 1.21.1
+Version: 1.21.2
 Authors@R: c(
 	person("Nicholas", "Cooley", email = "npc19@pitt.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6029-304X")),
 	person("Aidan", "Lakshman", email = "ahl27@pitt.edu", role = c("aut", "ctb"), comment = c(ORCID = "0000-0002-9465-6785")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,20 @@
+# SynExtend 1.21.2
+* Deprecated consensus clustering removed from `ExoLabel`
+* `ExoLabel` now supports argument `header=c(FALSE, TRUE, integer(1L))` to skip the first 0,1,n lines of each file (respectively)
+* `ExoLabel` now supports gzip-compressed files as input
+* Some examples in man pages have been made faster
+
+# SynExtend 1.21.1
+* Internal code reorganization for `ExoLabel`
+* Further arguments to `SuperTree` now correctly passthrough to `Treeline`
+* Some deprecated arguments to `EvoWeaver` have been removed
+
+# SynExtend 1.21.0
+* First development version of Bioconductor 3.22
+
+# SynExtend 1.20.0
+* Official Bioconductor 3.21 release
+
 # SynExtend 1.19.11
 * Fixes bug where `ExoLabel` wouldn't handle multiple files correctly
 * `ExoLabel` now reads in networks roughly twice as fast

--- a/R/ExoLabel.R
+++ b/R/ExoLabel.R
@@ -49,14 +49,10 @@ ExoLabel <- function(edgelistfiles,
                           ignore_weights=FALSE,
                           iterations=0L,
                           return_table=FALSE,
-                          consensus_cluster=FALSE,
                           use_fast_sort=TRUE,
                           verbose=interactive(),
                           sep='\t',
                           tempfiledir=tempdir()){
-  if(consensus_cluster != FALSE || length(consensus_cluster) != 1L){
-    stop("Consensus clustering is currently disabled.")
-  }
   if(return_table){
     maxp <- max(length(add_self_loops),
                 length(attenuation),
@@ -122,18 +118,6 @@ ExoLabel <- function(edgelistfiles,
       stop("file ", f, " has malformed weights")
   }
 
-  if(is.logical(consensus_cluster)){
-    if(consensus_cluster){
-      consensus_cluster <- c(0,0.2,0.4,0.6,0.8,1,1.33,1.67,2)
-    } else {
-      consensus_cluster <- numeric(0L)
-    }
-  } else {
-    if(!is.numeric(consensus_cluster) || any(is.na(consensus_cluster) | is.null(consensus_cluster)))
-      stop("'consensus_cluster' must be a logical or numeric vector")
-    if(any(consensus_cluster < 0))
-      stop("'consensus_cluster' cannot contain negative values")
-  }
   tempfiledir <- normalizePath(tempfiledir, mustWork=TRUE)
   tempfiledir <- file.path(tempfiledir, "ExoLabelTemp")
   if(dir.exists(tempfiledir)){
@@ -173,8 +157,8 @@ ExoLabel <- function(edgelistfiles,
                        tempfiledir, outfile, seps, iterations,
                        verbose_int, is_undirected,
                        add_self_loops, ignore_weights,
-                       consensus_cluster, !use_fast_sort,
-                       attenuation, attenuation, FALSE)
+                       !use_fast_sort,
+                       attenuation, FALSE)
   names(graph_stats) <- c("num_vertices", "num_edges")
   for(f in list.files(tempfiledir, full.names=TRUE))
     if(file.exists(f)) file.remove(f)
@@ -262,7 +246,6 @@ EstimateExoLabel <- function(num_v, avg_degree=2, is_undirected=TRUE,
                      attenuation=TRUE,
                      ignore_weights=FALSE,
                      iterations=0L,
-                     consensus_cluster=FALSE,
                      use_fast_sort=TRUE,
                      verbose=FALSE,
                      sep='\t',
@@ -291,13 +274,6 @@ EstimateExoLabel <- function(num_v, avg_degree=2, is_undirected=TRUE,
       stop("file ", f, " has malformed weights")
   }
 
-  if(is.logical(consensus_cluster)){
-    if(consensus_cluster){
-      consensus_cluster <- c(0,0.2,0.4,0.6,0.8,1,1.33,1.67,2)
-    } else {
-      consensus_cluster <- numeric(0L)
-    }
-  }
   tempfiledir <- normalizePath(tempfiledir, mustWork=TRUE)
   tempfiledir <- file.path(tempfiledir, "ExoLabelTemp")
   if(dir.exists(tempfiledir)){
@@ -343,8 +319,8 @@ EstimateExoLabel <- function(num_v, avg_degree=2, is_undirected=TRUE,
                        tempfiledir, outfile, seps, iterations,
                        verbose_int, is_undirected,
                        add_self_loops, ignore_weights,
-                       consensus_cluster, !use_fast_sort,
-                       attenuation, attenuation, TRUE)
+                       !use_fast_sort,
+                       attenuation, TRUE)
 
   if(verbose){
     cat('\n')

--- a/R/ExoLabel.R
+++ b/R/ExoLabel.R
@@ -70,7 +70,9 @@ ExoLabel <- function(edgelistfiles,
   add_self_loops <- .safecheck_optional_numeric("add_self_loops", add_self_loops, length(outfile))
 
   ## check header
-  if(is.logical(header)) header <- as.integer(header)
+  if(is.logical(header) || (is.numeric(header) && !is.integer(header)))
+    header <- as.integer(header)
+
   if(!is.integer(header) || is.na(header) || is.null(header)){
     stop("'header' must be a finite logical or integer value")
   }

--- a/R/ExoLabel.R
+++ b/R/ExoLabel.R
@@ -52,6 +52,7 @@ ExoLabel <- function(edgelistfiles,
                           use_fast_sort=TRUE,
                           verbose=interactive(),
                           sep='\t',
+                          header=FALSE,
                           tempfiledir=tempdir()){
   if(return_table){
     maxp <- max(length(add_self_loops),
@@ -67,6 +68,16 @@ ExoLabel <- function(edgelistfiles,
   iterations <- .safecheck_optional_integer("iterations", iterations, 32767L, TRUE, length(outfile))
   attenuation <- .safecheck_optional_numeric("attenuation", attenuation, length(outfile))
   add_self_loops <- .safecheck_optional_numeric("add_self_loops", add_self_loops, length(outfile))
+
+  ## check header
+  if(is.logical(header)) header <- as.integer(header)
+  if(!is.integer(header) || is.na(header) || is.null(header)){
+    stop("'header' must be a finite logical or integer value")
+  }
+  if(length(header) > 1){
+    header <- header[1]
+    warning("ignoring extra values passed to 'header'")
+  }
 
   if(any(add_self_loops < 0)){
     warning("self loops weight supplied is negative, setting to zero.")
@@ -158,7 +169,7 @@ ExoLabel <- function(edgelistfiles,
                        verbose_int, is_undirected,
                        add_self_loops, ignore_weights,
                        !use_fast_sort,
-                       attenuation, FALSE)
+                       attenuation, header, FALSE)
   names(graph_stats) <- c("num_vertices", "num_edges")
   for(f in list.files(tempfiledir, full.names=TRUE))
     if(file.exists(f)) file.remove(f)
@@ -249,6 +260,7 @@ EstimateExoLabel <- function(num_v, avg_degree=2, is_undirected=TRUE,
                      use_fast_sort=TRUE,
                      verbose=FALSE,
                      sep='\t',
+                     header=FALSE,
                      tempfiledir=tempdir(),
                      skip_checks=FALSE){
   verbose_int <- as.integer(verbose)
@@ -320,7 +332,7 @@ EstimateExoLabel <- function(num_v, avg_degree=2, is_undirected=TRUE,
                        verbose_int, is_undirected,
                        add_self_loops, ignore_weights,
                        !use_fast_sort,
-                       attenuation, TRUE)
+                       attenuation, header, TRUE)
 
   if(verbose){
     cat('\n')
@@ -335,7 +347,7 @@ EstimateExoLabel <- function(num_v, avg_degree=2, is_undirected=TRUE,
 
   benchmark_graph <- data.frame(v1=character(0L), v2=character(0L), w=numeric(0L))
   for(f in edgelistfiles){
-    tmp <- read.delim(f, header=FALSE, sep=sep)
+    tmp <- read.delim(f, header=FALSE, sep=sep, skip=as.integer(header))
     benchmark_graph <- rbind(benchmark_graph, tmp)
   }
   colnames(benchmark_graph) <- c("v1", "v2", "weight")

--- a/man/BuiltInEnsembles.Rd
+++ b/man/BuiltInEnsembles.Rd
@@ -26,18 +26,19 @@ See the examples for how to train your own ensemble model.
 \examples{
 ## Training own ensemble method to avoid using built-ins
 ## defaults to built-ins when an ensemble isn't provided
-
+set.seed(333L)
 exData <- get(data("ExampleStreptomycesData"))
-ew <- EvoWeaver(exData$Genes[seq_len(50L)], MySpeciesTree=exData$Tree)
+ew <- EvoWeaver(exData$Genes[seq_len(8L)], MySpeciesTree=exData$Tree, NoWarn=TRUE)
 datavals <- predict(ew, NoPrediction=TRUE, Verbose=interactive())
+datavals <- datavals[datavals[,1] != datavals[,2],]
 
 # Picking random numbers for demonstration purposes
-actual_values <- sample(c(0,1), nrow(datavals), replace=TRUE)
+actual_values <- sample(rep(c(1,0), length.out=nrow(datavals)))
 datavals[,'y'] <- actual_values
 myModel <- glm(y~., datavals[,-c(1,2)], family='binomial')
 
-predictionPW <- EvoWeaver(exData$Genes[51:60], MySpeciesTree=exData$Tree)
+predictionPW <- EvoWeaver(exData$Genes[9:10], MySpeciesTree=exData$Tree, NoWarn=TRUE)
 predict(predictionPW,
-          PretrainedModel=myModel, Verbose=interactive())
+          PretrainedModel=myModel, Verbose=interactive())[2,,drop=FALSE]
 }
 \keyword{datasets}

--- a/man/ExampleStreptomycesData.Rd
+++ b/man/ExampleStreptomycesData.Rd
@@ -27,8 +27,7 @@ of 301 unique genomes.
 }
 \examples{
 exData <- get(data("ExampleStreptomycesData"))
-ew <- EvoWeaver(exData$Genes)
-# Subset isn't necessary but is faster for a working example
-predict(ew, Subset=1:10, MySpeciesTree=exData$Tree)
+ew <- EvoWeaver(exData$Genes[seq_len(2L)], MySpeciesTree=exData$Tree, NoWarn=TRUE)
+predict(ew, Method="PAJaccard")
 }
 \keyword{datasets}

--- a/man/ExoLabel.Rd
+++ b/man/ExoLabel.Rd
@@ -69,7 +69,7 @@ Character; expected character that separates entries on a line in each file in \
 }
 
 \item{header}{
-Logical or Integer; determines if the first line of edgelist files should be skipped. If logical, \code{TRUE} skips the first line of each file.. If set to an integer \code{n}, skips the first \code{n} lines.
+Logical or Integer; determines if the first line of edgelist files should be skipped. If logical, \code{TRUE} skips the first line of each file.. If set to an integer \code{n}, skips the first \code{n} lines. Negative values are treated as 0, and decimals are coerced to integer.
 }
 
 \item{tempfiledir}{

--- a/man/ExoLabel.Rd
+++ b/man/ExoLabel.Rd
@@ -25,7 +25,7 @@ ExoLabel(edgelistfiles,
 
 \arguments{
 \item{edgelistfiles}{
-Character; vector of files to be processed. Each entry should be a machine-interpretable path to an edgelist file. See Details for expected format.
+Character; vector of files to be processed. Each entry should be a machine-interpretable path to an edgelist file. Plaintext and gzip-compressed files are currently supported. See Details for expected format.
 }
 
 \item{outfile}{

--- a/man/ExoLabel.Rd
+++ b/man/ExoLabel.Rd
@@ -16,7 +16,6 @@ ExoLabel(edgelistfiles,
               ignore_weights=FALSE,
               iterations=0L,
               return_table=FALSE,
-              consensus_cluster=FALSE,
               use_fast_sort=TRUE,
               verbose=interactive(),
               sep='\t',
@@ -54,10 +53,6 @@ Integer; maximum number of times to process each node. If set to zero or \code{N
 
 \item{return_table}{
 Logical; determines how the result of clustering is returned. If \code{FALSE} (default), returns a character vector corresponding to the path of \code{outfile}. If \code{TRUE}, parses \code{outfile} using \code{\link{read.table}} and returns the result (not recommended for very large graphs).
-}
-
-\item{consensus_cluster}{
-Logical or Numeric; determines if consensus clustering should be used. \bold{Currently disabled, but will be available in the next release.} If \code{TRUE}, runs the clustering algorithm nine times across varying parameters and forms a consensus clustering based on the agreement of each run. Can be set to a numeric vector to control the number of clusterings. See "Consensus Clustering" below for more information.
 }
 
 \item{use_fast_sort}{
@@ -119,15 +114,6 @@ Reading in the graph object takes a large portion of the processing time. This l
 Multiple clusterings on the same network are supported by passing vectors of input to \code{outfile} and \code{add_self_loops} or \code{attenuation}. If the length of \code{outfile} is greater than 1, \code{add_self_loops} and \code{attenuation} can each be set to either a single value or a vector of the same length as \code{outfile}. For a single value, the same parameter value will be used across all clusterings. For multiple values, the corresponding value will be used in each clustering. See "Examples" for example usage.
 
 Note that the order to process each node is randomly initialized, so multiple runs on the same parameters may produce different results if a random seed is not set.
-}
-
-\section{Consensus Clustering}{
-Consensus clustering is not yet available, but will be enabled in the next release.
-
-%Consensus clustering can be enabled by setting \code{consensus_cluster=TRUE}.
-Consensus clustering runs ExoLabel on the input graph multiple times, transforming weight values according to the sigmoid function \eqn{(1+\exp{(-s(w-\frac{1}{2})})^{-1}}, where \eqn{w} is the original weight and \eqn{s} is the shape parameter.
-
-By default, this runs nine times for shape parameters \code{c(0,0.2,0.4,0.6,0.8,1.0,1.33,1.67,2.0)}, collapsing weights below 0.1 to zero. The resulting clusters form a network such that the edge weight between any two nodes connected in the initial graph is the proportion of clusters they shared over clustering runs. This network is used for a final label propagation run, which identifies the consensus clusters. Users can specify a numeric vector as input to \code{consensus_cluster}, which will override the default shape parameters and number of iterations.
 }
 
 \value{

--- a/man/ExoLabel.Rd
+++ b/man/ExoLabel.Rd
@@ -19,6 +19,7 @@ ExoLabel(edgelistfiles,
               use_fast_sort=TRUE,
               verbose=interactive(),
               sep='\t',
+              header=FALSE,
               tempfiledir=tempdir())
 }
 
@@ -66,6 +67,11 @@ Logical; determines if status messages (output, progress, etc.) should be displa
 \item{sep}{
 Character; expected character that separates entries on a line in each file in \code{edgelistfiles}. Defaults to tab, as would be expected in a \code{.tsv} formatted file. Set to \code{','} for a \code{.csv} file. Also determines the separator used in the output table.
 }
+
+\item{header}{
+Logical or Integer; determines if the first line of edgelist files should be skipped. If logical, \code{TRUE} skips the first line of each file.. If set to an integer \code{n}, skips the first \code{n} lines.
+}
+
 \item{tempfiledir}{
 Character; vector corresponding to the location where temporary files used during execution should be stored. These temporary files are deleted after ExoLabel finishes running.
 }

--- a/src/ExoLabel/ExoLabel.h
+++ b/src/ExoLabel/ExoLabel.h
@@ -1,6 +1,7 @@
 #include "../SEutils.h"
 #include "PrefixTrie.h"
 #include "LoserTree.h"
+#include "FileHandlers.h"
 #include <time.h>
 
 // includes for file truncation

--- a/src/ExoLabel/ExoLabel.h
+++ b/src/ExoLabel/ExoLabel.h
@@ -58,8 +58,6 @@ static const int BITS_FOR_EXP = 4;
 static const double MIN_DOUBLE = -1 * DBL_MIN;
 static const int L_SIZE = sizeof(l_uint);
 static const int W_SIZE = sizeof(w_float);
-static const char CONSENSUS_CSRCOPY1[] = "tmpcsr1";
-static const char CONSENSUS_CLUSTER[] = "tmpclust";
 
 /*
  * Some comments on external sorting performance:
@@ -96,11 +94,4 @@ void cluster_file(const char* weights_fname,
                   const char* neighbor_fname,
                   const l_uint num_v, const int max_iterations, const int v,
                   const float self_loop_weight,
-                  const double atten_pow, const double dist_pow);
-
-void consensus_cluster_oom(const char* weightsfile,
-                          const char* neighborfile, const char* dir,
-                          const l_uint num_v, const int num_iter, const int v,
-                          const float self_loop_weight,
-                          const double atten_pow, const double dist_pow,
-                          const double* consensus_weights, const int consensus_len);
+                  const double atten_pow);

--- a/src/ExoLabel/FileHandlers.c
+++ b/src/ExoLabel/FileHandlers.c
@@ -1,0 +1,324 @@
+#include "FileHandlers.h"
+
+static void detect_file_type(const char *expath, int *ztype, int *subtype){
+  /*
+   * adapted from XVector/io_utils.c, which itself is taken from
+   * do_url() in R/src/main/connections.c
+   */
+  FILE *fp;
+  char buf[7];
+  int res;
+
+  *ztype = UNKNOWN;
+  *subtype = 0;
+  if ((fp = fopen(expath, "rb")) == NULL)
+    return;
+  memset(buf, 0, 7);
+  res = fread(buf, 5, 1, fp);
+  fclose(fp);
+  if (res != 1)
+    return;
+  if (buf[0] == '\x1f' && buf[1] == '\x8b')
+    *ztype = GZ_TYPE;
+  else if (strncmp(buf, "BZh", 3) == 0)
+    *ztype = BZ2_TYPE;
+  else if (buf[0] == '\xFD' && strncmp(buf+1, "7zXZ", 4) == 0)
+    *ztype = XZ_TYPE;
+  else if ((buf[0] == '\xFF') && strncmp(buf+1, "LZMA", 4) == 0) {
+    *ztype = XZ_TYPE;
+    *subtype = 1;
+  } else if (memcmp(buf, "]\0\0\200\0", 5) == 0) {
+    *ztype = XZ_TYPE;
+    *subtype = 1;
+  } else {
+    *ztype = UNCOMPRESSED;
+  }
+  return;
+}
+
+static void fopen_with_known_type(file_t *f, const char* path, const char *mode){
+  int ftype = f->file_type;
+  switch(ftype){
+  case UNCOMPRESSED:
+    f->file_ptr = fopen(path, mode);
+    break;
+  case GZ_TYPE:
+    f->file_ptr = gzopen(path, mode);
+    break;
+  case BZ2_TYPE:
+    error("Files compressed with bz2 are not yet supported (%s)", path);
+  case XZ_TYPE:
+    error("Files compressed with xz are not yet supported (%s)", path);
+  case UNKNOWN:
+  default:
+    error("Internal error calling fopen on file %s in mode %s.", path, mode);
+  }
+}
+
+static file_t *fopen_dispatch(const char* fpath, const char* mode, const int type){
+  file_t *file_holder = safe_malloc(sizeof(file_t));
+  file_holder->file_ptr = NULL;
+  file_holder->file_type = UNKNOWN;
+
+  // determine the file type
+  int ftype = type, fsubtype = 0;
+  if(ftype == UNKNOWN)
+    detect_file_type(fpath, &ftype, &fsubtype);
+
+  // subtype is currently ignored but may be used in the future if we add xz support
+  file_holder->file_type = ftype;
+
+  // open the file given that we now know its type
+  fopen_with_known_type(file_holder, fpath, mode);
+
+  return file_holder;
+}
+
+static int fclose_dispatch(file_t *f){
+  int ftype = f->file_type;
+  switch(ftype){
+  case UNCOMPRESSED:
+    return fclose(f->file_ptr);
+  case GZ_TYPE:
+    return gzclose(f->file_ptr);
+  case BZ2_TYPE:
+  case XZ_TYPE:
+  case UNKNOWN:
+  default:
+    // should never get here, since we can never open files in this way
+    error("Internal error attempting to call fclose on file with format %d",
+      f->file_type);
+  }
+};
+
+static size_t fread_dispatch(void *buf, size_t size, size_t count, file_t *f){
+  int ftype = f->file_type;
+  size_t bytes_read = 0;
+  switch(ftype){
+  case UNCOMPRESSED:
+    bytes_read = fread(buf, size, count, f->file_ptr);
+    break;
+  case GZ_TYPE:
+    bytes_read = gzread(f->file_ptr, buf, size*count);
+    break;
+  case BZ2_TYPE:
+  case XZ_TYPE:
+  case UNKNOWN:
+  default:
+    // should never get here, since we can never open files in this way
+    error("Internal error attempting to call fread on file with format %d",
+      f->file_type);
+  }
+  return bytes_read;
+}
+
+static size_t fwrite_dispatch(const void* buf, size_t size, size_t count, file_t *f){
+  int ftype = f->file_type;
+  size_t bytes_written = 0;
+  switch(ftype){
+  case UNCOMPRESSED:
+    bytes_written = fwrite(buf, size, count, f->file_ptr);
+    break;
+  case GZ_TYPE:
+    bytes_written = gzwrite(f->file_ptr, buf, size*count);
+    break;
+  case BZ2_TYPE:
+  case XZ_TYPE:
+  case UNKNOWN:
+  default:
+    // should never get here, since we can never open files in this way
+    error("Internal error attempting to call fwrite on file with format %d",
+      f->file_type);
+  }
+  return bytes_written;
+}
+
+static char getc_dispatch(file_t *f){
+  int ftype = f->file_type;
+  switch(ftype){
+  case UNCOMPRESSED:
+    return getc(f->file_ptr);
+  case GZ_TYPE:
+    return gzgetc((gzFile) f->file_ptr);
+  case BZ2_TYPE:
+  case XZ_TYPE:
+  case UNKNOWN:
+  default:
+    // should never get here, since we can never open files in this way
+    error("Internal error attempting to call getc on file with format %d",
+      f->file_type);
+  }
+  return 0;
+}
+
+static int fseek_dispatch(file_t *f, long offset, int origin){
+  int ftype = f->file_type;
+  int status = -1;
+  switch(ftype){
+  case UNCOMPRESSED:
+    status = fseek(f->file_ptr, offset, origin);
+    break;
+  case GZ_TYPE:
+    // note that SEEK_END may not be supported for gz files
+    status = gzseek(f->file_ptr, offset, origin);
+    break;
+  case BZ2_TYPE:
+  case XZ_TYPE:
+  case UNKNOWN:
+  default:
+    // should never get here, since we can never open files in this way
+    error("Internal error attempting to seek in file");
+  }
+  return status;
+}
+
+static long ftell_dispatch(file_t *f){
+  int ftype = f->file_type;
+  switch(ftype){
+  case UNCOMPRESSED:
+    return ftell(f->file_ptr);
+  case GZ_TYPE:
+    return gztell(f->file_ptr);
+  case BZ2_TYPE:
+  case XZ_TYPE:
+  case UNKNOWN:
+  default:
+    // should never get here, since we can never open files in this way
+    error("Internal error attempting to call getc() on file");
+  }
+  return -1;
+}
+
+static int feof_dispatch(file_t *f){
+  int ftype = f->file_type;
+  switch(ftype){
+  case UNCOMPRESSED:
+    return feof(f->file_ptr);
+  case GZ_TYPE:
+    return gzeof(f->file_ptr);
+  case BZ2_TYPE:
+  case XZ_TYPE:
+  case UNKNOWN:
+  default:
+    // should never get here, since we can never open files in this way
+    error("Internal error attempting to call feof() on file");
+  }
+  // default should be saying the file is closed to abort as early as possible
+  return 1;
+}
+
+/***************************/
+/* File Function Interface */
+/***************************/
+
+file_t *safe_fopen(const char* fpath, const char* mode, const int type){
+  file_t *f = fopen_dispatch(fpath, mode, type);
+  if(!f->file_ptr){
+    free(f);
+    error("Internal error calling fopen on file %s (Failed to open).", fpath);
+  }
+  return f;
+}
+
+void safe_fclose(file_t *f){
+  if(!f) error("Internal error calling fclose on null pointer.");
+
+  int status = fclose_dispatch(f);
+  if(status != 0)
+    error("Internal error calling fclose on file with format %d.", f->file_type);
+  free(f);
+  f = NULL;
+  return;
+}
+
+size_t safe_fread(void *buffer, size_t size, size_t count, file_t *stream){
+  size_t found_values = fread_dispatch(buffer, size, count, stream);
+  if(found_values != count){
+    // two scenarios:
+
+    // 1. read past the end of the file (throw error and return)
+    if(safe_feof(stream))
+      error("%s", "Internal error: fread tried to read past end of file.\n");
+
+    // 2. some undefined reading error (retry a few times and then return)
+    for(int i=0; i<MAX_READ_RETRIES; i++){
+      // if we read a partial value, reset the counter back
+      if(found_values) fseek_dispatch(stream, -1*((int)found_values), SEEK_CUR);
+
+      // try to read again
+      found_values = fread_dispatch(buffer, size, count, stream);
+      if(found_values == count) return found_values;
+    }
+
+    // otherwise throw an error
+    error("Internal error: fread read %zu values (expected %zu).\n", found_values, count);
+  }
+  return found_values;
+}
+
+size_t unsafe_fread(void *buffer, size_t size, size_t count, file_t *stream){
+  // this function doesn't ensure we read as many values as we expected
+  // it also doesn't retry on failure
+  return fread_dispatch(buffer, size, count, stream);
+}
+
+size_t safe_fwrite(void *buffer, size_t size, size_t count, file_t *stream){
+  size_t written_values = fwrite_dispatch(buffer, size, count, stream);
+  if(written_values != count){
+    // same scenarios as in safe_fread
+    if(safe_feof(stream))
+      error("%s", "Internal error: fread tried to read past end of file.\n");
+
+    for(int i=0; i<MAX_WRITE_RETRIES; i++){
+      // if we read a partial value, reset the counter back
+      if(written_values) fseek_dispatch(stream, -1*((int)written_values), SEEK_CUR);
+
+      // try to read again
+      written_values = fwrite_dispatch(buffer, size, count, stream);
+      if(written_values == count) return count;
+    }
+
+    // otherwise throw an error
+    error("Internal error: fwrite wrote %zu values (expected %zu).\n", written_values, count);
+  }
+  return written_values;
+}
+
+
+/*
+ * Below functions are simple wrappers
+ * not necessary but included for consistency with safe_fread, safe_fwrite
+ * can be extended later
+ */
+
+char safe_getc(file_t *f){
+  if(!f) error("Error calling getc on null pointer.");
+  return getc_dispatch(f);
+}
+
+int safe_fseek(file_t *f, long offset, int origin){
+  int status = fseek_dispatch(f, offset, origin);
+  if(status != 0) // basic error reporting on failure
+    error("Internal error calling fseek on file with format %d (offset %ld, origin %d, code %d).",
+          f->file_type, offset, origin, status);
+  return status;
+}
+
+void safe_rewind(file_t *f){
+  int status = fseek_dispatch(f, 0, SEEK_SET);
+  if(status != 0) // basic error reporting on failure
+    error("Internal error calling rewind on file with format %d (code %d).",
+          f->file_type, status);
+  return;
+}
+
+long safe_ftell(file_t *f){
+  long pos = ftell_dispatch(f);
+  if(pos == -1) // basic error reporting on failure
+    error("Internal error calling ftell on file with format %d.", f->file_type);
+  return pos;
+}
+
+int safe_feof(file_t *f){
+  return feof_dispatch(f);
+}

--- a/src/ExoLabel/FileHandlers.h
+++ b/src/ExoLabel/FileHandlers.h
@@ -1,0 +1,51 @@
+#ifndef FHANDLE_FILE
+#define FHANDLE_FILE
+
+#include <zlib.h>
+#include "../SEutils.h" // for safe_malloc
+
+/******************
+ * Functions to abstract file access interfaces
+ * Note that these do NOT do error checking for read/write failures
+ * These methods should be called via safe_fread, safe_fwrite, etc.,
+ * since those calls do ensure the correct number of bytes are read/written
+ ******************/
+
+
+/*
+// not currently supported
+#ifdef _WIN32
+  #include <bzlib.h>
+#endif
+*/
+
+enum {
+  UNKNOWN = 0,
+  UNCOMPRESSED,
+  GZ_TYPE,
+  BZ2_TYPE,
+  XZ_TYPE,
+};
+
+typedef struct file_t {
+  void *file_ptr;
+  int file_type;
+} file_t;
+
+static const int MAX_READ_RETRIES = 10;
+static const int MAX_WRITE_RETRIES = 10;
+
+/*** externally exposed methods ***/
+file_t *safe_fopen(const char* fpath, const char* mode, const int type);
+void safe_fclose(file_t *f);
+size_t safe_fread(void *buffer, size_t size, size_t count, file_t *stream);
+size_t unsafe_fread(void *buffer, size_t size, size_t count, file_t *stream);
+size_t safe_fwrite(void *buffer, size_t size, size_t count, file_t *stream);
+char safe_getc(file_t *f);
+int safe_fseek(file_t *f, long offset, int origin);
+void safe_rewind(file_t *f);
+long safe_ftell(file_t *f);
+int safe_feof(file_t *f);
+
+
+#endif

--- a/src/ExoLabel/LoserTree.h
+++ b/src/ExoLabel/LoserTree.h
@@ -2,6 +2,7 @@
 #define LOSERTREE_H
 
 #include "../SEutils.h"
+#include "FileHandlers.h"
 
 /*
  * This is intended to be a type-unaware LoserTree (Tournament Tree)
@@ -60,12 +61,12 @@ void LT_popOutput(LoserTree *tree);
 void LT_updateTree(LoserTree *tree);
 void LT_refillBin(LoserTree *tree, int bin, int nelem, void *input);
 size_t LT_dumpOutput(LoserTree *tree, void *output_buffer);
-size_t LT_fdumpOutput(LoserTree *tree, FILE *f);
+size_t LT_fdumpOutput(LoserTree *tree, file_t *f);
 size_t LT_fdumpOutputInplace(LoserTree *tree, size_t block_end,
-                            FILE *f, long int *remaining, long int **offsets);
-int LT_runFileGame(LoserTree *tree, FILE *f);
+                            file_t *f, long int *remaining, long int **offsets);
+int LT_runFileGame(LoserTree *tree, file_t *f);
 int LT_runInplaceFileGame(LoserTree *tree, size_t block_end,
-                          FILE *f, long int *remaining, long int **offsets);
+                          file_t *f, long int *remaining, long int **offsets);
 void LT_free(LoserTree *tree);
 
 #endif

--- a/src/Makevars
+++ b/src/Makevars
@@ -15,8 +15,9 @@ PKG_C_SOURCES = \
   SEutils.c \
   XORRand.c \
   ExoLabel/ExoLabel.c \
-  ExoLabel/LoserTree.c \
+  ExoLabel/FileHandlers.c \
   ExoLabel/PrefixTrie.c \
+  ExoLabel/LoserTree.c \
 
 # Fortran source files
 PKG_F_SOURCES = \

--- a/src/R_init_synextend.c
+++ b/src/R_init_synextend.c
@@ -56,7 +56,7 @@ static const R_CallMethodDef callMethods[] = { // method call, pointer, num args
   CALLDEF(do_dendrapply, 4),
   CALLDEF(se_cophenetic, 5),
   CALLDEF(MIForSequenceSets, 7),
-  CALLDEF(R_LPOOM_cluster, 13),
+  CALLDEF(R_LPOOM_cluster, 14),
   CALLDEF(R_learn_tree, 9),
   CALLDEF(R_get_treeptr, 4),
   CALLDEF(R_rfpredict, 4),

--- a/src/R_init_synextend.c
+++ b/src/R_init_synextend.c
@@ -56,7 +56,7 @@ static const R_CallMethodDef callMethods[] = { // method call, pointer, num args
   CALLDEF(do_dendrapply, 4),
   CALLDEF(se_cophenetic, 5),
   CALLDEF(MIForSequenceSets, 7),
-  CALLDEF(R_LPOOM_cluster, 15),
+  CALLDEF(R_LPOOM_cluster, 13),
   CALLDEF(R_learn_tree, 9),
   CALLDEF(R_get_treeptr, 4),
   CALLDEF(R_rfpredict, 4),

--- a/src/SEutils.c
+++ b/src/SEutils.c
@@ -29,57 +29,6 @@ void *safe_realloc(void *ptr, size_t new_size){
   return ptr;
 }
 
-/**************************/
-/* File Function Wrappers */
-/**************************/
-
-size_t safe_fread(void *buffer, size_t size, size_t count, FILE *stream){
-  size_t found_values = fread(buffer, size, count, stream);
-  if(found_values != count){
-    // two scenarios:
-
-    // 1. read past the end of the file (throw error and return)
-    if(feof(stream))
-      error("%s", "Internal error: fread tried to read past end of file.\n");
-
-    // 2. some undefined reading error (retry a few times and then return)
-    for(int i=0; i<MAX_READ_RETRIES; i++){
-      // if we read a partial value, reset the counter back
-      if(found_values) fseek(stream, -1*((int)found_values), SEEK_CUR);
-
-      // try to read again
-      found_values = fread(buffer, size, count, stream);
-      if(found_values == count) return found_values;
-    }
-
-    // otherwise throw an error
-    error("Internal error: fread read %zu values (expected %zu).\n", found_values, count);
-  }
-  return found_values;
-}
-
-size_t safe_fwrite(void *buffer, size_t size, size_t count, FILE *stream){
-  size_t written_values = fwrite(buffer, size, count, stream);
-  if(written_values != count){
-    // same scenarios as in safe_fread
-    if(feof(stream))
-      error("%s", "Internal error: fread tried to read past end of file.\n");
-
-    for(int i=0; i<MAX_WRITE_RETRIES; i++){
-      // if we read a partial value, reset the counter back
-      if(written_values) fseek(stream, -1*((int)written_values), SEEK_CUR);
-
-      // try to read again
-      written_values = fwrite(buffer, size, count, stream);
-      if(written_values == count) return count;
-    }
-
-    // otherwise throw an error
-    error("Internal error: fwrite wrote %zu values (expected %zu).\n", written_values, count);
-  }
-  return written_values;
-}
-
 /****************************/
 /* Random Number Generation */
 /****************************/

--- a/src/SEutils.h
+++ b/src/SEutils.h
@@ -20,13 +20,6 @@ void *safe_malloc(size_t size);
 void *safe_calloc(size_t nitems, size_t size);
 void *safe_realloc(void *ptr, size_t new_size);
 
-
-/*** File read/write wrappers ***/
-static const int MAX_READ_RETRIES = 10;
-static const int MAX_WRITE_RETRIES = 10;
-size_t safe_fread(void *buffer, size_t size, size_t count, FILE *stream);
-size_t safe_fwrite(void *buffer, size_t size, size_t count, FILE *stream);
-
 /*** Other Utility Functions ***/
 inline void *void_deref(void *v, int i, size_t size){
   return i ? (void *)((char *)v + (i*size)) : v;

--- a/tests/test_ExoLabel.R
+++ b/tests/test_ExoLabel.R
@@ -20,65 +20,82 @@ run_status_tests <- function(){
   tf2 <- tempfile()
   WEIGHT_TOLERANCE <- 0.001
   testExo <- SynExtend:::.testExoLabel
-  cat("Small graphs:...")
-  for(loop in c(0, 0.25, 0.5)){
-    df <- generate_random_graph(10, 25)
-    if(any(abs(df$w - loop) < WEIGHT_TOLERANCE))
-      df$w[abs(df$w - loop) < WEIGHT_TOLERANCE] <- df$w[abs(df$w - loop) < WEIGHT_TOLERANCE] + 3*WEIGHT_TOLERANCE
+
+  file_fxns <- list(
+    none=\(x) {},
+    gz=\(x){ system(paste("gzip", "-f", x))}
+  )
+  file_endings <- c("", ".gz")
+
+  for(i in seq_along(file_fxns)){
+    cat("File Compression:", names(file_fxns)[i], '\n')
+
+    to_process <- paste0(c(tf1, tf2), file_endings[i])
+    elf1 <- to_process[1]
+    elf2 <- to_process[2]
+
+    cat("\tSmall graphs:...")
+    for(loop in c(0, 0.25, 0.5)){
+      df <- generate_random_graph(10, 25)
+      if(any(abs(df$w - loop) < WEIGHT_TOLERANCE))
+        df$w[abs(df$w - loop) < WEIGHT_TOLERANCE] <- df$w[abs(df$w - loop) < WEIGHT_TOLERANCE] + 3*WEIGHT_TOLERANCE
+      write.table(df, tf1, row.names=FALSE, col.names=FALSE, quote=FALSE, sep='\t')
+      file_fxns[[i]](tf1)
+      testExo(elf1, add_self_loops=loop)
+    }
+    cat("passed.\n")
+
+    cat("\tLarger graphs:...")
+    for(loop in c(0, 0.5)){
+      df <- generate_random_graph(10000, 25000)
+      if(any(abs(df$w - loop) < WEIGHT_TOLERANCE))
+        df$w[abs(df$w - loop) < WEIGHT_TOLERANCE] <- df$w[abs(df$w - loop) < WEIGHT_TOLERANCE] + 3*WEIGHT_TOLERANCE
+      write.table(df, tf1, row.names=FALSE, col.names=FALSE, quote=FALSE, sep='\t')
+      file_fxns[[i]](tf1)
+      testExo(elf1, add_self_loops=loop)
+    }
+    cat("passed.\n")
+
+
+    cat("\tDirected Edges...")
+    testExo(elf1, mode="directed")
+    cat("passed.\n")
+
+    cat("\tNo fast sort...")
+    testExo(elf1, use_fast_sort=FALSE)
+    cat("passed.\n")
+
+    ## I'll just use the same graph here
+    cat("\tDifferent separator...")
+    write.table(df, tf1, row.names=FALSE, col.names=FALSE, quote=FALSE, sep=',')
+    file_fxns[[i]](tf1)
+    testExo(elf1, sep=',')
+    cat("passed.\n")
+
+    cat("\tMulti-file input...")
+    df <- generate_random_graph(50000, 100000)
+    write.table(df[1:50000,], tf1, row.names=FALSE, col.names=FALSE, quote=FALSE, sep='\t')
+    write.table(df[50000:100000,], tf2, row.names=FALSE, col.names=FALSE, quote=FALSE, sep='\t')
+    file_fxns[[i]](tf1)
+    file_fxns[[i]](tf2)
+    testExo(c(elf1, elf2))
+    cat("passed.\n")
+
+    cat("\tHeaders...")
+    testExo(c(elf1, elf2), header=TRUE)
+    testExo(c(elf1, elf2), header=10L)
+    cat("passed.\n")
+
+    cat("\tLarger weights...")
+    df[,3] <- df[,3] * 1000
     write.table(df, tf1, row.names=FALSE, col.names=FALSE, quote=FALSE, sep='\t')
-    testExo(tf1, add_self_loops=loop)
+    file_fxns[[i]](tf1)
+    testExo(elf1)
+    cat("passed.\n")
+
+    file.remove(elf1)
+    file.remove(elf2)
   }
-  cat("passed.\n")
-
-  cat("Larger graphs:...")
-  for(loop in c(0, 0.5)){
-    df <- generate_random_graph(10000, 25000)
-    if(any(abs(df$w - loop) < WEIGHT_TOLERANCE))
-      df$w[abs(df$w - loop) < WEIGHT_TOLERANCE] <- df$w[abs(df$w - loop) < WEIGHT_TOLERANCE] + 3*WEIGHT_TOLERANCE
-    write.table(df, tf1, row.names=FALSE, col.names=FALSE, quote=FALSE, sep='\t')
-    testExo(tf1, add_self_loops=loop)
-  }
-  cat("passed.\n")
-
-
-  cat("Directed Edges...")
-  testExo(tf1, mode="directed")
-  cat("passed.\n")
-
-  cat("No fast sort...")
-  testExo(tf1, use_fast_sort=FALSE)
-  cat("passed.\n")
-
-  ## I'll just use the same graph here
-  cat("Different separator...")
-  write.table(df, tf1, row.names=FALSE, col.names=FALSE, quote=FALSE, sep=',')
-  testExo(tf1, sep=',')
-  cat("passed.\n")
-
-  cat("Multi-file input...")
-  tf2 <- tempfile()
-  df <- generate_random_graph(50000, 100000)
-  write.table(df[1:50000,], tf1, row.names=FALSE, col.names=FALSE, quote=FALSE, sep='\t')
-  write.table(df[50000:100000,], tf2, row.names=FALSE, col.names=FALSE, quote=FALSE, sep='\t')
-  testExo(c(tf1, tf2))
-  cat("passed.\n")
-
-  cat("Headers...")
-  testExo(c(tf1, tf2), header=TRUE)
-  testExo(c(tf1, tf2), header=10L)
-  cat("passed.\n")
-
-
-  cat("Larger weights...")
-  df[,3] <- df[,3] * 1000
-  write.table(df, tf1, row.names=FALSE, col.names=FALSE, quote=FALSE, sep='\t')
-  testExo(tf1)
-  cat("passed.\n")
-
-  file.remove(tf1)
-  file.remove(tf2)
-
-
 
   cat("\nAll checks passed!\n")
   invisible(TRUE)

--- a/tests/test_ExoLabel.R
+++ b/tests/test_ExoLabel.R
@@ -10,8 +10,6 @@ generate_random_graph <- function(nverts, nedges){
   data.frame(v1=labs[df[,1]], v2=labs[df[,2]], w=runif(nedges))
 }
 
-
-
 run_status_tests <- function(){
   if(!require(igraph)){
     cat("Skipping tests, igraph is not available.\n")
@@ -65,6 +63,12 @@ run_status_tests <- function(){
   testExo(c(tf1, tf2))
   cat("passed.\n")
 
+  cat("Headers...")
+  testExo(c(tf1, tf2), header=TRUE)
+  testExo(c(tf1, tf2), header=10L)
+  cat("passed.\n")
+
+
   cat("Larger weights...")
   df[,3] <- df[,3] * 1000
   write.table(df, tf1, row.names=FALSE, col.names=FALSE, quote=FALSE, sep='\t')
@@ -73,6 +77,8 @@ run_status_tests <- function(){
 
   file.remove(tf1)
   file.remove(tf2)
+
+
 
   cat("\nAll checks passed!\n")
   invisible(TRUE)


### PR DESCRIPTION
* Removes useless consensus argument for `ExoLabel`
* Adds `header` argument to `ExoLabel` to support skipping the first `n` lines (also accepts `T/F` to skip the first line or no lines, respectively)
* Some slower examples in man pages have been adjusted to run much more quickly